### PR TITLE
Run resize stress tests in CI

### DIFF
--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -42,13 +42,24 @@ jobs:
         name: Enable debug symbols
       - name: cargo test -Zsanitizer=address
         # only --lib --tests b/c of https://github.com/rust-lang/rust/issues/53945
-        run: RUSTFLAGS="--cfg papaya_asan" cargo test --lib --tests --all-features --target x86_64-unknown-linux-gnu
+        run: cargo test --lib --tests --all-features --target x86_64-unknown-linux-gnu
         env:
           ASAN_OPTIONS: "detect_odr_violation=0:detect_leaks=0"
-          RUSTFLAGS: "-Z sanitizer=address"
+          RUSTFLAGS: "-Z sanitizer=address --cfg papaya_asan"
+      - name: stress tests -Zsanitizer=address
+        run: cargo test --lib --tests --all-features --target x86_64-unknown-linux-gnu -- --ignored --test-threads 1
+        env:
+          ASAN_OPTIONS: "detect_odr_violation=0:detect_leaks=0"
+          RUSTFLAGS: "-Z sanitizer=address --cfg papaya_asan"
       - name: cargo test -Zsanitizer=leak
         if: always()
         run: cargo test --all-features --target x86_64-unknown-linux-gnu
+        env:
+          LSAN_OPTIONS: "suppressions=lsan-suppressions.txt"
+          RUSTFLAGS: "-Z sanitizer=leak"
+      - name: stress tests -Zsanitizer=leak
+        if: always()
+        run: cargo test --all-features --target x86_64-unknown-linux-gnu -- --ignored --test-threads 1
         env:
           LSAN_OPTIONS: "suppressions=lsan-suppressions.txt"
           RUSTFLAGS: "-Z sanitizer=leak"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,12 +55,6 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
     steps:
-      # if your project needs OpenSSL, uncomment this to fix Windows builds.
-      # it's commented out by default as the install command takes 5-10m.
-      # - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-      #   if: runner.os == 'Windows'
-      # - run: vcpkg install openssl:x64-windows-static-md
-      #   if: runner.os == 'Windows'
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -71,6 +65,27 @@ jobs:
         run: cargo generate-lockfile
       - name: cargo test
         run: cargo test --locked --all-features --all-targets
-      # run stress tests serially, as they individually spawn many threads to provoke contention
       - name: stress tests
         run: cargo test -- --ignored --test-threads 1
+  stress:
+    # run resize stress tests on linux and mac
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    name: ${{ matrix.os }} / stable
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: cargo generate-lockfile
+        if: hashFiles('Cargo.lock') == ''
+        run: cargo generate-lockfile
+      - name: stress tests
+        run: cargo test --locked -- --ignored --test-threads 1
+        env:
+          RUSTFLAGS: "--cfg papaya_stress"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
     # run resize stress tests on linux and mac
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
-    name: ${{ matrix.os }} / stable
+    name: ${{ matrix.os }} / stress
     strategy:
       fail-fast: false
       matrix:

--- a/tests/cuckoo.rs
+++ b/tests/cuckoo.rs
@@ -180,6 +180,7 @@ fn stress_find_thread(env: Arc<Environment>) {
 
 #[test]
 #[ignore]
+#[cfg(not(papaya_stress))]
 fn stress_test_blocking() {
     let mut root = Environment::new();
     root.table1 = HashMap::builder().resize_mode(ResizeMode::Blocking).build();
@@ -228,8 +229,11 @@ fn run(root: Arc<Environment>) {
     for t in threads {
         t.join().expect("failed to join thread");
     }
-    let in_table = &*root.in_table.lock().unwrap();
-    let num_filled = in_table.iter().filter(|b| **b).count();
-    assert_eq!(num_filled, root.table1.pin().len());
-    assert_eq!(num_filled, root.table2.pin().len());
+
+    if !cfg!(papaya_stress) {
+        let in_table = &*root.in_table.lock().unwrap();
+        let num_filled = in_table.iter().filter(|b| **b).count();
+        assert_eq!(num_filled, root.table1.pin().len());
+        assert_eq!(num_filled, root.table2.pin().len());
+    }
 }

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -59,7 +59,7 @@ fn contains_key_stress() {
 fn insert_stress() {
     const ENTRIES: usize = match () {
         _ if cfg!(miri) => 64,
-        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 11,
+        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 12,
         _ => 1 << 17,
     };
     const ITERATIONS: usize = if cfg!(miri) { 1 } else { 32 };
@@ -181,7 +181,7 @@ fn update_stress() {
     const ENTRIES: usize = if cfg!(miri) { 64 } else { 256 };
     const OPERATIONS: usize = match () {
         _ if cfg!(miri) => 1,
-        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 10,
+        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 9,
         _ => 1 << 10,
     };
     const ITERATIONS: usize = if cfg!(miri) { 1 } else { 48 };
@@ -299,7 +299,7 @@ fn update_or_insert_stress() {
     const ENTRIES: usize = if cfg!(miri) { 64 } else { 256 };
     const OPERATIONS: usize = match () {
         _ if cfg!(miri) => 1,
-        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 10,
+        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 9,
         _ => 1 << 10,
     };
     const ITERATIONS: usize = if cfg!(miri) { 1 } else { 48 };
@@ -436,7 +436,7 @@ fn conditional_remove_update_or_insert_stress() {
     const ENTRIES: usize = if cfg!(miri) { 64 } else { 256 };
     const OPERATIONS: usize = match () {
         _ if cfg!(miri) => 1,
-        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 4,
+        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 5,
         _ => 1 << 9,
     };
     const ITERATIONS: usize = if cfg!(miri) { 1 } else { 32 };
@@ -519,7 +519,7 @@ fn insert_remove_stress() {
     const ENTRIES: usize = if cfg!(miri) { 64 } else { 256 };
     const OPERATIONS: usize = match () {
         _ if cfg!(miri) => 1,
-        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 7,
+        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 8,
         _ => 1 << 9,
     };
     const ITERATIONS: usize = if cfg!(miri) { 1 } else { 48 };
@@ -586,7 +586,7 @@ fn insert_remove_stress() {
 fn remove_mixed_stress() {
     const ENTRIES: usize = match () {
         _ if cfg!(miri) => 64,
-        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 12,
+        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 11,
         _ => 1 << 17,
     };
     const ITERATIONS: usize = if cfg!(miri) { 1 } else { 64 };
@@ -670,7 +670,7 @@ fn remove_mixed_stress() {
 fn insert_remove_chunk_stress() {
     const ENTRIES: usize = match () {
         _ if cfg!(miri) => 48,
-        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 10,
+        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 11,
         _ => 1 << 17,
     };
     const ITERATIONS: usize = if cfg!(miri) { 1 } else { 48 };
@@ -735,7 +735,7 @@ fn insert_remove_chunk_stress() {
 fn mixed_chunk_stress() {
     const ENTRIES: usize = match () {
         _ if cfg!(miri) => 48,
-        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 10,
+        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 11,
         _ => 1 << 16,
     };
     const ITERATIONS: usize = if cfg!(miri) { 1 } else { 32 };
@@ -815,7 +815,7 @@ fn mixed_chunk_stress() {
 fn mixed_entry_stress() {
     const ENTRIES: usize = match () {
         _ if cfg!(miri) => 100,
-        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 10,
+        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 11,
         _ => 1 << 11,
     };
     const OPERATIONS: usize = if cfg!(miri) { 1 } else { 72 };
@@ -879,11 +879,11 @@ fn mixed_entry_stress() {
 fn everything() {
     const SIZE: usize = match () {
         _ if cfg!(miri) => 1 << 5,
-        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 8,
+        _ if cfg!(papaya_stress) || cfg!(papaya_asan) => 1 << 13,
         _ => 1 << 20,
     };
-    // there must be more things absent than present!
-    const ABSENT_SIZE: usize = if cfg!(miri) { 1 << 6 } else { 1 << 22 };
+    // There must be more things absent than present!
+    const ABSENT_SIZE: usize = SIZE << 1;
     const ABSENT_MASK: usize = ABSENT_SIZE - 1;
 
     let mut rng = rand::thread_rng();


### PR DESCRIPTION
Would eventually like a cron job that runs these with larger tables, but this is good enough for now. See https://github.com/ibraheemdev/papaya/issues/3.