### PR TITLE
implement `HashMap::retain`

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -858,6 +858,31 @@ where
         self.raw.root(guard).clear(guard)
     }
 
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all pairs `(k, v)` for which `f(&k, &v)` returns `false`.
+    /// The elements are visited in unsorted (and unspecified) order.
+    ///
+    /// Note the function may be called more than once for a given key if its value is
+    /// concurrently modified during removal.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use papaya::HashMap;
+    ///
+    /// let mut map: HashMap<i32, i32> = (0..8).map(|x| (x, x * 10)).collect();
+    /// map.pin().retain(|&k, _| k % 2 == 0);
+    /// assert_eq!(map.len(), 4);
+    /// ```
+    #[inline]
+    pub fn retain<F>(&mut self, f: F, guard: &impl Guard)
+    where
+        F: FnMut(&K, &V) -> bool,
+    {
+        self.raw.root(guard).retain(f, guard)
+    }
+
     /// An iterator visiting all key-value pairs in arbitrary order.
     /// The iterator element type is `(&K, &V)`.
     ///
@@ -1345,6 +1370,17 @@ where
     #[inline]
     pub fn clear(&self) {
         self.root().clear(&self.guard)
+    }
+
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// See [`HashMap::retain`] for details.
+    #[inline]
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&K, &V) -> bool,
+    {
+        self.root().retain(f, &self.guard)
     }
 
     /// Tries to reserve capacity for `additional` more elements to be inserted

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -894,6 +894,8 @@ where
         // Get a clean copy of the table to delete from.
         self.linearize(guard);
 
+        // Note that this method is not implemented in terms of `retain(|_, _| true)` to avoid
+        // loading entry metadata, as there is no need to provide consistency with `get`.
         let mut copying = false;
         'probe: for i in 0..self.table.len() {
             // Load the entry to delete.

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -690,7 +690,7 @@ fn len() {
         for i in 0..len {
             map.pin().insert(i, i + 1);
         }
-        assert_eq!(map.pin().len(), len);
+        assert_eq!(map.len(), len);
     });
 }
 
@@ -711,6 +711,54 @@ fn iter() {
         let mut got: Vec<_> = map.pin().iter().map(|(&k, &v)| (k, v)).collect();
         got.sort();
         assert_eq!(v, got);
+    });
+}
+
+#[test]
+fn retain_empty() {
+    with_map::<usize, usize>(|map| {
+        let map = map();
+        map.pin().retain(|_, _| false);
+        assert_eq!(map.len(), 0);
+    });
+}
+
+#[test]
+fn retain_all_false() {
+    with_map::<usize, usize>(|map| {
+        let map = map();
+        for i in 0..10 {
+            map.pin().insert(i, i);
+        }
+        map.pin().retain(|_, _| false);
+        assert_eq!(map.len(), 0);
+    });
+}
+
+#[test]
+fn retain_all_true() {
+    with_map::<usize, usize>(|map| {
+        let map = map();
+        for i in 0..10 {
+            map.pin().insert(i, i);
+        }
+        map.pin().retain(|_, _| true);
+        assert_eq!(map.len(), 10);
+    });
+}
+
+#[test]
+fn retain_some() {
+    with_map::<usize, usize>(|map| {
+        let map = map();
+        for i in 0..10 {
+            map.pin().insert(i, i);
+        }
+        map.pin().retain(|_, v| *v >= 5);
+        assert_eq!(map.len(), 5);
+        let mut got: Vec<_> = map.pin().values().copied().collect();
+        got.sort();
+        assert_eq!(got, [5, 6, 7, 8, 9]);
     });
 }
 


### PR DESCRIPTION
Implements `HashMap::retain`. Resolves https://github.com/ibraheemdev/papaya/issues/24.