### PR TITLE
Add `Equivalence` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["concurrent", "hashmap", "atomic", "lock-free"]
 exclude = ["assets/*"]
 
 [dependencies]
+equivalent = "1"
 seize = "0.4"
 serde = { version = "1", optional = true }
 
@@ -34,7 +35,10 @@ inherits = "release"
 debug-assertions = true
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(papaya_stress)', 'cfg(papaya_asan)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(papaya_stress)',
+    'cfg(papaya_asan)',
+] }
 
 [[bench]]
 name = "single_thread"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,10 +229,10 @@ mod set;
 #[cfg(feature = "serde")]
 mod serde_impls;
 
+pub use equivalent::Equivalent;
 pub use map::{
     Compute, HashMap, HashMapBuilder, HashMapRef, Iter, Keys, OccupiedError, Operation, ResizeMode,
     Values,
 };
-pub use raw::Equivalent;
 pub use seize::{Guard, LocalGuard, OwnedGuard};
 pub use set::{HashSet, HashSetBuilder, HashSetRef};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,5 +233,6 @@ pub use map::{
     Compute, HashMap, HashMapBuilder, HashMapRef, Iter, Keys, OccupiedError, Operation, ResizeMode,
     Values,
 };
+pub use raw::Equivalent;
 pub use seize::{Guard, LocalGuard, OwnedGuard};
 pub use set::{HashSet, HashSetBuilder, HashSetRef};

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,4 +1,5 @@
 use crate::raw::{self, InsertResult};
+use crate::Equivalent;
 use seize::{Collector, Guard, LocalGuard, OwnedGuard};
 
 use std::borrow::Borrow;
@@ -457,37 +458,6 @@ where
         }
     }
 
-    /// Returns a reference to the value with the given `hash` and which
-    /// satisfies the equality function passed.
-    ///
-    /// This function is similar to [`Self::get()`], but provides a shortcut
-    /// for lookups where instantiation of keys is expensive. For instance, if
-    /// creating the key requires allocation, this can be avoided by using
-    /// this method.
-    ///
-    /// As a caller, you are responsible for using the correct hasher, and
-    /// making sure the equality function only returns `true` for the key you
-    /// are looking for.
-    #[inline]
-    pub fn get_by_hash<'g, Q>(
-        &self,
-        hash: u64,
-        eq: impl Fn(&Q) -> bool,
-        guard: &'g impl Guard,
-    ) -> Option<&'g V>
-    where
-        K: Borrow<Q> + 'g,
-        Q: Hash + Eq + ?Sized,
-    {
-        self.raw.check_guard(guard);
-
-        // Safety: Checked the guard above.
-        match unsafe { self.raw.get_by_hash(hash, eq, guard) } {
-            Some((_, v)) => Some(v),
-            None => None,
-        }
-    }
-
     /// Returns the key-value pair corresponding to the supplied key.
     ///
     /// The supplied key may be any borrowed form of the map's key type, but
@@ -510,8 +480,7 @@ where
     #[inline]
     pub fn get_key_value<'g, Q>(&self, key: &Q, guard: &'g impl Guard) -> Option<(&'g K, &'g V)>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         self.raw.check_guard(guard);
 
@@ -1321,28 +1290,10 @@ where
     #[inline]
     pub fn get<Q>(&self, key: &Q) -> Option<&V>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         // Safety: `self.guard` was created from our map.
         match unsafe { self.map.raw.get(key, &self.guard) } {
-            Some((_, v)) => Some(v),
-            None => None,
-        }
-    }
-
-    /// Returns a reference to the value with the given `hash` and which
-    /// satisfies the equality function passed.
-    ///
-    /// See [`HashMap::get_by_hash`] for details.
-    #[inline]
-    pub fn get_by_hash<Q>(&self, hash: u64, eq: impl Fn(&Q) -> bool) -> Option<&V>
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
-    {
-        // Safety: `self.guard` was created from our map.
-        match unsafe { self.map.raw.get_by_hash(hash, eq, &self.guard) } {
             Some((_, v)) => Some(v),
             None => None,
         }
@@ -1354,8 +1305,7 @@ where
     #[inline]
     pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         // Safety: `self.guard` was created from our map.
         unsafe { self.map.raw.get(key, &self.guard) }

--- a/src/map.rs
+++ b/src/map.rs
@@ -418,8 +418,7 @@ where
     #[inline]
     pub fn contains_key<Q>(&self, key: &Q, guard: &impl Guard) -> bool
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         self.get(key, guard).is_some()
     }
@@ -446,8 +445,8 @@ where
     #[inline]
     pub fn get<'g, Q>(&self, key: &Q, guard: &'g impl Guard) -> Option<&'g V>
     where
-        K: Borrow<Q> + 'g,
-        Q: Hash + Eq + ?Sized,
+        K: 'g,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         self.raw.check_guard(guard);
 
@@ -1278,8 +1277,7 @@ where
     #[inline]
     pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         self.get(key).is_some()
     }

--- a/src/map.rs
+++ b/src/map.rs
@@ -814,8 +814,8 @@ where
     #[inline]
     pub fn remove<'g, Q>(&self, key: &Q, guard: &'g impl Guard) -> Option<&'g V>
     where
-        K: Borrow<Q> + 'g,
-        Q: Hash + Eq + ?Sized,
+        K: 'g,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         self.raw.check_guard(guard);
 
@@ -847,8 +847,8 @@ where
     #[inline]
     pub fn remove_entry<'g, Q>(&self, key: &Q, guard: &'g impl Guard) -> Option<(&'g K, &'g V)>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        K: 'g,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         self.raw.check_guard(guard);
 

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -13,6 +13,7 @@ use self::alloc::{RawTable, Table};
 use self::probe::Probe;
 use self::utils::{untagged, AtomicPtrFetchOps, Counter, Parker, Shared, StrictProvenance, Tagged};
 use crate::map::{Compute, Operation, ResizeMode};
+use crate::Equivalent;
 
 use seize::{AsLink, Collector, Guard, Link};
 
@@ -2332,34 +2333,6 @@ where
                 }
             }
         }
-    }
-}
-
-/// Key equivalence trait.
-///
-/// This trait allows hash table lookups to be customized. It has one blanket
-/// implementation that uses the regular solution with `Borrow` and `Eq`, just
-/// like [std::collections::HashMap] does, so that you can pass `&str` to lookup
-/// into a map with `String` keys and so on.
-///
-/// ## Contract
-///
-/// The implementor must hash like K, if it is hashable.
-pub trait Equivalent<K>
-where
-    K: ?Sized,
-{
-    /// Compares `self` to `key` and returns whether they are equal.
-    fn equivalent(&self, key: &K) -> bool;
-}
-
-impl<Q, K> Equivalent<K> for Q
-where
-    Q: Eq + ?Sized,
-    K: Borrow<Q> + ?Sized,
-{
-    fn equivalent(&self, key: &K) -> bool {
-        self.eq(key.borrow())
     }
 }
 

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,4 +1,5 @@
 use crate::raw::{self, InsertResult};
+use crate::Equivalent;
 use seize::{Collector, Guard, LocalGuard, OwnedGuard};
 
 use crate::map::ResizeMode;
@@ -394,44 +395,12 @@ where
     #[inline]
     pub fn get<'g, Q>(&self, key: &Q, guard: &'g impl Guard) -> Option<&'g K>
     where
-        K: Borrow<Q> + 'g,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         self.raw.check_guard(guard);
 
         // Safety: Checked the guard above.
         match unsafe { self.raw.get(key, guard) } {
-            Some((k, _)) => Some(k),
-            None => None,
-        }
-    }
-
-    /// Returns a reference to the value with the given `hash` and which
-    /// satisfies the equality function passed.
-    ///
-    /// This function is similar to [`Self::get()`], but provides a shortcut
-    /// for lookups where instantiation of keys is expensive. For instance, if
-    /// creating the key requires allocation, this can be avoided by using
-    /// this method.
-    ///
-    /// As a caller, you are responsible for using the correct hasher, and
-    /// making sure the equality function only returns `true` for the key you
-    /// are looking for.
-    #[inline]
-    pub fn get_by_hash<'g, Q>(
-        &self,
-        hash: u64,
-        eq: impl Fn(&Q) -> bool,
-        guard: &'g impl Guard,
-    ) -> Option<&'g K>
-    where
-        K: Borrow<Q> + 'g,
-        Q: Hash + Eq + ?Sized,
-    {
-        self.raw.check_guard(guard);
-
-        // Safety: Checked the guard above.
-        match unsafe { self.raw.get_by_hash(hash, eq, guard) } {
             Some((k, _)) => Some(k),
             None => None,
         }
@@ -815,28 +784,10 @@ where
     #[inline]
     pub fn get<Q>(&self, key: &Q) -> Option<&K>
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         // Safety: `self.guard` was created from our map.
         match unsafe { self.set.raw.get(key, &self.guard) } {
-            Some((k, _)) => Some(k),
-            None => None,
-        }
-    }
-
-    /// Returns a reference to the value with the given `hash` and which
-    /// satisfies the equality function passed.
-    ///
-    /// See [`HashSet::get_by_hash`] for details.
-    #[inline]
-    pub fn get_by_hash<Q>(&self, hash: u64, eq: impl Fn(&Q) -> bool) -> Option<&K>
-    where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
-    {
-        // Safety: `self.guard` was created from our map.
-        match unsafe { self.set.raw.get_by_hash(hash, eq, &self.guard) } {
             Some((k, _)) => Some(k),
             None => None,
         }

--- a/src/set.rs
+++ b/src/set.rs
@@ -367,8 +367,7 @@ where
     #[inline]
     pub fn contains<Q>(&self, key: &Q, guard: &impl Guard) -> bool
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         self.get(key, guard).is_some()
     }
@@ -772,8 +771,7 @@ where
     #[inline]
     pub fn contains<Q>(&self, key: &Q) -> bool
     where
-        K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         self.get(key).is_some()
     }

--- a/src/set.rs
+++ b/src/set.rs
@@ -458,10 +458,9 @@ where
     /// assert_eq!(set.pin().remove(&1), false);
     /// ```
     #[inline]
-    pub fn remove<'g, Q>(&self, key: &Q, guard: &'g impl Guard) -> bool
+    pub fn remove<Q>(&self, key: &Q, guard: &impl Guard) -> bool
     where
-        K: Borrow<Q> + 'g,
-        Q: Hash + Eq + ?Sized,
+        Q: Equivalent<K> + Hash + ?Sized,
     {
         self.raw.check_guard(guard);
 


### PR DESCRIPTION
This PR adds `get_by_hash()` methods that allow for faster lookups when instantiating keys is expensive.

I figured I could get away without writing tests, since the implementation of `get()` now uses this method internally, so it's implicitly covered :)