### PR TITLE
Add `HashMap::remove_if`

### DIFF
--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -71,6 +71,26 @@ fn remove_empty() {
 }
 
 #[test]
+fn remove_if() {
+    with_map::<usize, usize>(|map| {
+        let map = map();
+
+        assert_eq!(map.pin().remove_if(&1, |_k, _v| true), Ok(None));
+
+        map.pin().insert(1, 0);
+
+        assert_eq!(map.pin().remove_if(&0, |_k, _v| true), Ok(None));
+        assert_eq!(map.pin().remove_if(&1, |_k, _v| false), Err((&1, &0)));
+        assert_eq!(map.pin().remove_if(&1, |_k, v| *v == 1), Err((&1, &0)));
+
+        assert_eq!(map.pin().get(&1), Some(&0));
+
+        assert_eq!(map.pin().remove_if(&1, |_k, v| *v == 0), Ok(Some((&1, &0))));
+        assert_eq!(map.pin().remove_if(&1, |_, _| true), Ok(None));
+    });
+}
+
+#[test]
 fn insert_and_remove() {
     with_map::<usize, usize>(|map| {
         let map = map();


### PR DESCRIPTION
I don't love the `_if` naming, but it is clear and [`Vec::extract_if` is being stablized](https://github.com/rust-lang/rust/issues/43244) so at least there is precedent.

Resolves https://github.com/ibraheemdev/papaya/issues/53. cc @tatsuya6502