### PR TITLE
Update to seize 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["assets/*"]
 
 [dependencies]
 equivalent = "1"
-seize = "0.4"
+seize = "0.5"
 serde = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/assets/Exchange.ahash.latency.svg
+++ b/assets/Exchange.ahash.latency.svg
@@ -271,10 +271,10 @@ Latency
 850 ns
 </text>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,56 565,56 "/>
-<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="80,401 126,387 188,378 249,369 311,359 373,346 435,334 497,327 559,311 "/>
-<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="80,380 126,317 188,279 249,225 311,155 373,114 435,73 497,58 559,36 "/>
-<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="1" points="80,400 126,384 188,374 249,368 311,358 373,340 435,327 497,322 559,301 "/>
-<polyline fill="none" opacity="1" stroke="#FF00FF" stroke-width="1" points="80,388 126,382 188,377 249,371 311,362 373,348 435,344 497,337 559,331 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="80,400 126,385 188,378 249,366 311,356 373,345 435,333 497,324 559,315 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="80,382 126,320 188,273 249,216 311,160 373,120 435,86 497,61 559,36 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="1" points="80,401 126,386 188,377 249,368 311,359 373,344 435,337 497,324 559,318 "/>
+<polyline fill="none" opacity="1" stroke="#FF00FF" stroke-width="1" points="80,391 126,383 188,376 249,371 311,358 373,352 435,344 497,339 559,335 "/>
 <rect x="85" y="41" width="95" height="79" opacity="0.8" fill="#FFFFFF" stroke="none"/>
 <rect x="85" y="41" width="95" height="79" opacity="1" fill="none" stroke="#000000"/>
 <text x="125" y="51" dy="0.76em" text-anchor="start" font-family="Fira Code" font-size="10.483870967741936" opacity="1" fill="#000000">
@@ -287,7 +287,7 @@ Flurry
 Papaya
 </text>
 <text x="125" y="100" dy="0.76em" text-anchor="start" font-family="Fira Code" font-size="10.483870967741936" opacity="1" fill="#000000">
-SccMap
+Scc
 </text>
 <polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="95,56 115,56 "/>
 <polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="95,72 115,72 "/>

--- a/assets/Exchange.ahash.throughput.svg
+++ b/assets/Exchange.ahash.throughput.svg
@@ -65,34 +65,34 @@ Throughput
 0 Mop/s
 </text>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,429 79,429 "/>
-<text x="70" y="375" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<text x="70" y="377" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 20 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,375 79,375 "/>
-<text x="70" y="320" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,377 79,377 "/>
+<text x="70" y="324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 40 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,320 79,320 "/>
-<text x="70" y="265" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,324 79,324 "/>
+<text x="70" y="271" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 60 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,265 79,265 "/>
-<text x="70" y="210" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,271 79,271 "/>
+<text x="70" y="218" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 80 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,210 79,210 "/>
-<text x="70" y="155" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,218 79,218 "/>
+<text x="70" y="165" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 100 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,155 79,155 "/>
-<text x="70" y="100" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,165 79,165 "/>
+<text x="70" y="113" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 120 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,100 79,100 "/>
-<text x="70" y="45" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,113 79,113 "/>
+<text x="70" y="60" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 140 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,45 79,45 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,60 79,60 "/>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,430 559,430 "/>
 <text x="95" y="440" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 2
@@ -163,38 +163,38 @@ Throughput
 0 Mop/s
 </text>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,429 565,429 "/>
-<text x="617" y="375" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<text x="617" y="377" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 20 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,375 565,375 "/>
-<text x="617" y="320" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,377 565,377 "/>
+<text x="617" y="324" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 40 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,320 565,320 "/>
-<text x="617" y="265" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,324 565,324 "/>
+<text x="617" y="271" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 60 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,265 565,265 "/>
-<text x="617" y="210" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,271 565,271 "/>
+<text x="617" y="218" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 80 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,210 565,210 "/>
-<text x="570" y="155" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,218 565,218 "/>
+<text x="570" y="165" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 100 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,155 565,155 "/>
-<text x="570" y="100" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,165 565,165 "/>
+<text x="570" y="113" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 120 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,100 565,100 "/>
-<text x="570" y="45" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,113 565,113 "/>
+<text x="570" y="60" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 140 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,45 565,45 "/>
-<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="80,388 126,317 188,242 249,189 311,158 373,142 435,128 497,101 559,105 "/>
-<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="80,405 126,387 188,365 249,359 311,359 373,353 435,348 497,339 559,331 "/>
-<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="1" points="80,389 126,323 188,256 249,195 311,160 373,160 435,149 497,115 559,129 "/>
-<polyline fill="none" opacity="1" stroke="#FF00FF" stroke-width="1" points="80,401 126,328 188,246 249,180 311,143 373,133 435,92 497,66 559,36 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,60 565,60 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="80,390 126,326 188,249 249,211 311,179 373,155 435,142 497,120 559,105 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="80,405 126,387 188,370 249,364 311,361 373,355 435,348 497,341 559,335 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="1" points="80,389 126,323 188,253 249,202 311,168 373,157 435,128 497,120 559,98 "/>
+<polyline fill="none" opacity="1" stroke="#FF00FF" stroke-width="1" points="80,400 126,330 188,255 249,194 311,172 373,132 435,104 497,74 559,36 "/>
 <rect x="85" y="41" width="95" height="79" opacity="0.8" fill="#FFFFFF" stroke="none"/>
 <rect x="85" y="41" width="95" height="79" opacity="1" fill="none" stroke="#000000"/>
 <text x="125" y="51" dy="0.76em" text-anchor="start" font-family="Fira Code" font-size="10.483870967741936" opacity="1" fill="#000000">
@@ -207,7 +207,7 @@ Flurry
 Papaya
 </text>
 <text x="125" y="100" dy="0.76em" text-anchor="start" font-family="Fira Code" font-size="10.483870967741936" opacity="1" fill="#000000">
-SccMap
+Scc
 </text>
 <polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="95,56 115,56 "/>
 <polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="95,72 115,72 "/>

--- a/assets/RapidGrow.ahash.latency.svg
+++ b/assets/RapidGrow.ahash.latency.svg
@@ -65,46 +65,42 @@ Latency
 0 ns
 </text>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,429 79,429 "/>
-<text x="70" y="390" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<text x="70" y="389" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 100 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,390 79,390 "/>
-<text x="70" y="351" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,389 79,389 "/>
+<text x="70" y="348" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 200 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,351 79,351 "/>
-<text x="70" y="312" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,348 79,348 "/>
+<text x="70" y="308" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 300 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,312 79,312 "/>
-<text x="70" y="273" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,308 79,308 "/>
+<text x="70" y="267" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 400 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,273 79,273 "/>
-<text x="70" y="234" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,267 79,267 "/>
+<text x="70" y="226" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 500 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,234 79,234 "/>
-<text x="70" y="194" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,226 79,226 "/>
+<text x="70" y="186" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 600 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,194 79,194 "/>
-<text x="70" y="155" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,186 79,186 "/>
+<text x="70" y="145" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 700 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,155 79,155 "/>
-<text x="70" y="116" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,145 79,145 "/>
+<text x="70" y="104" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 800 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,116 79,116 "/>
-<text x="70" y="77" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,104 79,104 "/>
+<text x="70" y="64" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 900 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,77 79,77 "/>
-<text x="70" y="38" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
-1000 ns
-</text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,38 79,38 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,64 79,64 "/>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,430 559,430 "/>
 <text x="95" y="440" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 2
@@ -171,54 +167,50 @@ Latency
 </text>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="559,430 559,435 "/>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,36 560,429 "/>
-<text x="605" y="429" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<text x="599" y="429" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 0 ns
 </text>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,429 565,429 "/>
-<text x="605" y="390" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<text x="570" y="389" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 100 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,390 565,390 "/>
-<text x="605" y="351" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,389 565,389 "/>
+<text x="570" y="348" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 200 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,351 565,351 "/>
-<text x="605" y="312" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,348 565,348 "/>
+<text x="570" y="308" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 300 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,312 565,312 "/>
-<text x="605" y="273" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,308 565,308 "/>
+<text x="570" y="267" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 400 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,273 565,273 "/>
-<text x="605" y="234" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,267 565,267 "/>
+<text x="570" y="226" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 500 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,234 565,234 "/>
-<text x="605" y="194" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,226 565,226 "/>
+<text x="570" y="186" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 600 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,194 565,194 "/>
-<text x="605" y="155" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,186 565,186 "/>
+<text x="570" y="145" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 700 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,155 565,155 "/>
-<text x="605" y="116" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,145 565,145 "/>
+<text x="570" y="104" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 800 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,116 565,116 "/>
-<text x="605" y="77" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,104 565,104 "/>
+<text x="570" y="64" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 900 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,77 565,77 "/>
-<text x="570" y="38" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
-1000 ns
-</text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,38 565,38 "/>
-<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="80,406 126,390 188,381 249,374 311,362 373,348 435,336 497,318 559,315 "/>
-<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="80,392 126,333 188,268 249,218 311,154 373,109 435,82 497,69 559,36 "/>
-<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="1" points="80,404 126,397 188,391 249,387 311,373 373,366 435,348 497,351 559,335 "/>
-<polyline fill="none" opacity="1" stroke="#FF00FF" stroke-width="1" points="80,394 126,387 188,380 249,366 311,357 373,346 435,341 497,339 559,328 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,64 565,64 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="80,406 126,388 188,379 249,368 311,363 373,350 435,333 497,323 559,318 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="80,392 126,333 188,248 249,207 311,142 373,93 435,67 497,47 559,36 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="1" points="80,406 126,400 188,393 249,389 311,377 373,372 435,361 497,356 559,345 "/>
+<polyline fill="none" opacity="1" stroke="#FF00FF" stroke-width="1" points="80,394 126,386 188,378 249,373 311,359 373,349 435,342 497,336 559,327 "/>
 <rect x="85" y="41" width="95" height="79" opacity="0.8" fill="#FFFFFF" stroke="none"/>
 <rect x="85" y="41" width="95" height="79" opacity="1" fill="none" stroke="#000000"/>
 <text x="125" y="51" dy="0.76em" text-anchor="start" font-family="Fira Code" font-size="10.483870967741936" opacity="1" fill="#000000">
@@ -231,7 +223,7 @@ Flurry
 Papaya
 </text>
 <text x="125" y="100" dy="0.76em" text-anchor="start" font-family="Fira Code" font-size="10.483870967741936" opacity="1" fill="#000000">
-SccMap
+Scc
 </text>
 <polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="95,56 115,56 "/>
 <polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="95,72 115,72 "/>

--- a/assets/RapidGrow.ahash.throughput.svg
+++ b/assets/RapidGrow.ahash.throughput.svg
@@ -65,30 +65,34 @@ Throughput
 0 Mop/s
 </text>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,429 79,429 "/>
-<text x="70" y="373" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<text x="70" y="379" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 20 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,373 79,373 "/>
-<text x="70" y="316" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,379 79,379 "/>
+<text x="70" y="328" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 40 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,316 79,316 "/>
-<text x="70" y="260" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,328 79,328 "/>
+<text x="70" y="278" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 60 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,260 79,260 "/>
-<text x="70" y="203" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,278 79,278 "/>
+<text x="70" y="227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 80 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,203 79,203 "/>
-<text x="70" y="146" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,227 79,227 "/>
+<text x="70" y="177" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 100 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,146 79,146 "/>
-<text x="70" y="90" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,177 79,177 "/>
+<text x="70" y="126" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 120 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,90 79,90 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,126 79,126 "/>
+<text x="70" y="75" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+140 Mop/s
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,75 79,75 "/>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,430 559,430 "/>
 <text x="95" y="440" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 2
@@ -159,34 +163,38 @@ Throughput
 0 Mop/s
 </text>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,429 565,429 "/>
-<text x="617" y="373" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<text x="617" y="379" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 20 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,373 565,373 "/>
-<text x="617" y="316" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,379 565,379 "/>
+<text x="617" y="328" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 40 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,316 565,316 "/>
-<text x="617" y="260" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,328 565,328 "/>
+<text x="617" y="278" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 60 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,260 565,260 "/>
-<text x="617" y="203" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,278 565,278 "/>
+<text x="617" y="227" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 80 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,203 565,203 "/>
-<text x="570" y="146" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,227 565,227 "/>
+<text x="570" y="177" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 100 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,146 565,146 "/>
-<text x="570" y="90" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,177 565,177 "/>
+<text x="570" y="126" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 120 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,90 565,90 "/>
-<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="80,384 126,319 188,248 249,190 311,168 373,158 435,144 497,151 559,119 "/>
-<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="80,400 126,383 188,375 249,367 311,365 373,360 435,353 497,343 559,339 "/>
-<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="1" points="80,386 126,292 188,200 249,120 311,116 373,78 435,103 497,36 559,54 "/>
-<polyline fill="none" opacity="1" stroke="#FF00FF" stroke-width="1" points="80,399 126,325 188,250 249,219 311,183 373,163 435,131 497,87 559,81 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,126 565,126 "/>
+<text x="570" y="75" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+140 Mop/s
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,75 565,75 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="80,387 126,331 188,268 249,229 311,184 373,173 435,174 497,161 559,135 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="80,402 126,387 188,384 249,374 311,372 373,368 435,361 497,354 559,346 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="1" points="80,386 126,292 188,205 249,129 311,119 373,74 435,69 497,36 559,42 "/>
+<polyline fill="none" opacity="1" stroke="#FF00FF" stroke-width="1" points="80,401 126,335 188,270 249,214 311,196 373,174 435,149 497,124 559,107 "/>
 <rect x="85" y="41" width="95" height="79" opacity="0.8" fill="#FFFFFF" stroke="none"/>
 <rect x="85" y="41" width="95" height="79" opacity="1" fill="none" stroke="#000000"/>
 <text x="125" y="51" dy="0.76em" text-anchor="start" font-family="Fira Code" font-size="10.483870967741936" opacity="1" fill="#000000">
@@ -199,7 +207,7 @@ Flurry
 Papaya
 </text>
 <text x="125" y="100" dy="0.76em" text-anchor="start" font-family="Fira Code" font-size="10.483870967741936" opacity="1" fill="#000000">
-SccMap
+Scc
 </text>
 <polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="95,56 115,56 "/>
 <polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="95,72 115,72 "/>

--- a/assets/ReadHeavy.ahash.latency.svg
+++ b/assets/ReadHeavy.ahash.latency.svg
@@ -65,82 +65,78 @@ Latency
 0 ns
 </text>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,429 79,429 "/>
-<text x="70" y="410" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<text x="70" y="408" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 10 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,410 79,410 "/>
-<text x="70" y="390" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,408 79,408 "/>
+<text x="70" y="386" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 20 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,390 79,390 "/>
-<text x="70" y="370" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,386 79,386 "/>
+<text x="70" y="364" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 30 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,370 79,370 "/>
-<text x="70" y="350" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,364 79,364 "/>
+<text x="70" y="343" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 40 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,350 79,350 "/>
-<text x="70" y="330" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,343 79,343 "/>
+<text x="70" y="321" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 50 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,330 79,330 "/>
-<text x="70" y="310" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,321 79,321 "/>
+<text x="70" y="299" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 60 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,310 79,310 "/>
-<text x="70" y="290" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,299 79,299 "/>
+<text x="70" y="278" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 70 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,290 79,290 "/>
-<text x="70" y="270" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,278 79,278 "/>
+<text x="70" y="256" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 80 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,270 79,270 "/>
-<text x="70" y="250" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,256 79,256 "/>
+<text x="70" y="234" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 90 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,250 79,250 "/>
-<text x="70" y="230" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,234 79,234 "/>
+<text x="70" y="212" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 100 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,230 79,230 "/>
-<text x="70" y="210" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,212 79,212 "/>
+<text x="70" y="191" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 110 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,210 79,210 "/>
-<text x="70" y="190" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,191 79,191 "/>
+<text x="70" y="169" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 120 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,190 79,190 "/>
-<text x="70" y="170" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,169 79,169 "/>
+<text x="70" y="147" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 130 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,170 79,170 "/>
-<text x="70" y="150" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,147 79,147 "/>
+<text x="70" y="126" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 140 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,150 79,150 "/>
-<text x="70" y="130" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,126 79,126 "/>
+<text x="70" y="104" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 150 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,130 79,130 "/>
-<text x="70" y="110" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,104 79,104 "/>
+<text x="70" y="82" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 160 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,110 79,110 "/>
-<text x="70" y="90" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,82 79,82 "/>
+<text x="70" y="60" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 170 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,90 79,90 "/>
-<text x="70" y="70" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,60 79,60 "/>
+<text x="70" y="39" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 180 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,70 79,70 "/>
-<text x="70" y="50" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
-190 ns
-</text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,50 79,50 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,39 79,39 "/>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,430 559,430 "/>
 <text x="95" y="440" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 2
@@ -211,86 +207,82 @@ Latency
 0 ns
 </text>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,429 565,429 "/>
-<text x="599" y="410" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<text x="599" y="408" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 10 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,410 565,410 "/>
-<text x="599" y="390" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,408 565,408 "/>
+<text x="599" y="386" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 20 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,390 565,390 "/>
-<text x="599" y="370" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,386 565,386 "/>
+<text x="599" y="364" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 30 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,370 565,370 "/>
-<text x="599" y="350" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,364 565,364 "/>
+<text x="599" y="343" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 40 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,350 565,350 "/>
-<text x="599" y="330" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,343 565,343 "/>
+<text x="599" y="321" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 50 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,330 565,330 "/>
-<text x="599" y="310" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,321 565,321 "/>
+<text x="599" y="299" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 60 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,310 565,310 "/>
-<text x="599" y="290" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,299 565,299 "/>
+<text x="599" y="278" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 70 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,290 565,290 "/>
-<text x="599" y="270" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,278 565,278 "/>
+<text x="599" y="256" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 80 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,270 565,270 "/>
-<text x="599" y="250" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,256 565,256 "/>
+<text x="599" y="234" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 90 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,250 565,250 "/>
-<text x="570" y="230" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,234 565,234 "/>
+<text x="570" y="212" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 100 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,230 565,230 "/>
-<text x="570" y="210" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,212 565,212 "/>
+<text x="570" y="191" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 110 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,210 565,210 "/>
-<text x="570" y="190" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,191 565,191 "/>
+<text x="570" y="169" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 120 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,190 565,190 "/>
-<text x="570" y="170" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,169 565,169 "/>
+<text x="570" y="147" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 130 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,170 565,170 "/>
-<text x="570" y="150" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,147 565,147 "/>
+<text x="570" y="126" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 140 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,150 565,150 "/>
-<text x="570" y="130" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,126 565,126 "/>
+<text x="570" y="104" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 150 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,130 565,130 "/>
-<text x="570" y="110" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,104 565,104 "/>
+<text x="570" y="82" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 160 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,110 565,110 "/>
-<text x="570" y="90" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,82 565,82 "/>
+<text x="570" y="60" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 170 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,90 565,90 "/>
-<text x="570" y="70" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,60 565,60 "/>
+<text x="570" y="39" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 180 ns
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,70 565,70 "/>
-<text x="570" y="50" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
-190 ns
-</text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,50 565,50 "/>
-<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="80,338 126,274 188,258 249,238 311,210 373,182 435,106 497,144 559,78 "/>
-<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="80,302 126,288 188,266 249,242 311,190 373,112 435,114 497,68 559,36 "/>
-<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="1" points="80,350 126,350 188,346 249,332 311,296 373,288 435,252 497,268 559,232 "/>
-<polyline fill="none" opacity="1" stroke="#FF00FF" stroke-width="1" points="80,314 126,254 188,240 249,212 311,208 373,150 435,126 497,120 559,110 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,39 565,39 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="80,338 126,262 188,243 249,221 311,204 373,160 435,121 497,106 559,73 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="80,295 126,280 188,254 249,223 311,147 373,112 435,82 497,63 559,36 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="1" points="80,354 126,345 188,343 249,330 311,297 373,267 435,256 497,260 559,249 "/>
+<polyline fill="none" opacity="1" stroke="#FF00FF" stroke-width="1" points="80,304 126,245 188,225 249,199 311,195 373,126 435,102 497,91 559,39 "/>
 <rect x="85" y="41" width="95" height="79" opacity="0.8" fill="#FFFFFF" stroke="none"/>
 <rect x="85" y="41" width="95" height="79" opacity="1" fill="none" stroke="#000000"/>
 <text x="125" y="51" dy="0.76em" text-anchor="start" font-family="Fira Code" font-size="10.483870967741936" opacity="1" fill="#000000">
@@ -303,7 +295,7 @@ Flurry
 Papaya
 </text>
 <text x="125" y="100" dy="0.76em" text-anchor="start" font-family="Fira Code" font-size="10.483870967741936" opacity="1" fill="#000000">
-SccMap
+Scc
 </text>
 <polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="95,56 115,56 "/>
 <polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="95,72 115,72 "/>

--- a/assets/ReadHeavy.ahash.throughput.svg
+++ b/assets/ReadHeavy.ahash.throughput.svg
@@ -65,30 +65,34 @@ Throughput
 0 Mop/s
 </text>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,429 79,429 "/>
-<text x="70" y="372" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<text x="70" y="378" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 50 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,372 79,372 "/>
-<text x="70" y="314" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,378 79,378 "/>
+<text x="70" y="327" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 100 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,314 79,314 "/>
-<text x="70" y="257" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,327 79,327 "/>
+<text x="70" y="276" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 150 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,257 79,257 "/>
-<text x="70" y="199" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,276 79,276 "/>
+<text x="70" y="225" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 200 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,199 79,199 "/>
-<text x="70" y="142" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,225 79,225 "/>
+<text x="70" y="173" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 250 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,142 79,142 "/>
-<text x="70" y="84" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,173 79,173 "/>
+<text x="70" y="122" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 300 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,84 79,84 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,122 79,122 "/>
+<text x="70" y="71" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+350 Mop/s
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="74,71 79,71 "/>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="80,430 559,430 "/>
 <text x="95" y="440" dy="0.76em" text-anchor="middle" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 2
@@ -159,34 +163,38 @@ Throughput
 0 Mop/s
 </text>
 <polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,429 565,429 "/>
-<text x="617" y="372" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<text x="617" y="378" dy="0.5ex" text-anchor="end" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 50 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,372 565,372 "/>
-<text x="570" y="314" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,378 565,378 "/>
+<text x="570" y="327" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 100 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,314 565,314 "/>
-<text x="570" y="257" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,327 565,327 "/>
+<text x="570" y="276" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 150 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,257 565,257 "/>
-<text x="570" y="199" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,276 565,276 "/>
+<text x="570" y="225" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 200 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,199 565,199 "/>
-<text x="570" y="142" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,225 565,225 "/>
+<text x="570" y="173" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 250 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,142 565,142 "/>
-<text x="570" y="84" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,173 565,173 "/>
+<text x="570" y="122" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
 300 Mop/s
 </text>
-<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,84 565,84 "/>
-<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="80,405 126,371 188,323 249,286 311,264 373,245 435,259 497,206 559,221 "/>
-<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="80,412 126,365 188,318 249,284 311,277 373,285 435,256 497,252 559,243 "/>
-<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="1" points="80,401 126,316 188,211 249,150 311,158 373,106 435,122 497,36 559,61 "/>
-<polyline fill="none" opacity="1" stroke="#FF00FF" stroke-width="1" points="80,410 126,378 188,333 249,303 311,264 373,266 435,249 497,222 559,200 "/>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,122 565,122 "/>
+<text x="570" y="71" dy="0.5ex" text-anchor="start" font-family="sans-serif" font-size="9.67741935483871" opacity="1" fill="#000000">
+350 Mop/s
+</text>
+<polyline fill="none" opacity="1" stroke="#000000" stroke-width="1" points="560,71 565,71 "/>
+<polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="80,405 126,377 188,335 249,302 311,272 373,264 435,256 497,237 559,230 "/>
+<polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="80,413 126,370 188,329 249,300 311,304 373,290 435,276 497,260 559,249 "/>
+<polyline fill="none" opacity="1" stroke="#00FF00" stroke-width="1" points="80,401 126,326 188,229 249,167 311,161 373,158 435,124 497,65 559,36 "/>
+<polyline fill="none" opacity="1" stroke="#FF00FF" stroke-width="1" points="80,412 126,382 188,343 249,314 311,279 373,284 435,267 497,246 559,248 "/>
 <rect x="85" y="41" width="95" height="79" opacity="0.8" fill="#FFFFFF" stroke="none"/>
 <rect x="85" y="41" width="95" height="79" opacity="1" fill="none" stroke="#000000"/>
 <text x="125" y="51" dy="0.76em" text-anchor="start" font-family="Fira Code" font-size="10.483870967741936" opacity="1" fill="#000000">
@@ -199,7 +207,7 @@ Flurry
 Papaya
 </text>
 <text x="125" y="100" dy="0.76em" text-anchor="start" font-family="Fira Code" font-size="10.483870967741936" opacity="1" fill="#000000">
-SccMap
+Scc
 </text>
 <polyline fill="none" opacity="1" stroke="#0000FF" stroke-width="1" points="95,56 115,56 "/>
 <polyline fill="none" opacity="1" stroke="#FF0000" stroke-width="1" points="95,72 115,72 "/>

--- a/benches/single_thread.rs
+++ b/benches/single_thread.rs
@@ -29,7 +29,7 @@ fn compare(c: &mut Criterion) {
 
     group.bench_function("papaya", |b| {
         let m = papaya::HashMap::<usize, usize>::builder()
-            .collector(seize::Collector::new().epoch_frequency(None))
+            .collector(seize::Collector::new())
             .build();
 
         for i in RandomKeys::new().take(SIZE) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,8 @@
 #![allow(unstable_name_collisions)]
 // Stylistic preferences.
 #![allow(clippy::multiple_bound_locations, clippy::single_match)]
+// Clippy trips up with pollyfills.
+#![allow(clippy::incompatible_msrv)]
 
 mod map;
 mod raw;

--- a/src/map.rs
+++ b/src/map.rs
@@ -1093,7 +1093,7 @@ where
         let (guard1, guard2) = (&self.guard(), &other.guard());
 
         let mut iter = self.iter(guard1);
-        iter.all(|(key, value)| other.get(key, guard2).map_or(false, |v| *value == *v))
+        iter.all(|(key, value)| other.get(key, guard2).is_some_and(|v| *value == *v))
     }
 }
 
@@ -1205,7 +1205,7 @@ where
         let other = HashMap::builder()
             .capacity(self.len())
             .hasher(self.raw.hasher.clone())
-            .collector(self.raw.collector().clone())
+            .collector(seize::Collector::new())
             .build();
 
         {

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1,5 +1,6 @@
 mod alloc;
 mod probe;
+
 pub(crate) mod utils;
 
 use std::hash::{BuildHasher, Hash};
@@ -10,12 +11,12 @@ use std::{hint, panic, ptr};
 
 use self::alloc::{RawTable, Table};
 use self::probe::Probe;
-use self::utils::{untagged, AtomicPtrFetchOps, Counter, Parker, Shared, StrictProvenance, Tagged};
+use self::utils::{untagged, AtomicPtrFetchOps, Counter, Parker, StrictProvenance, Tagged};
 use crate::map::{Compute, Operation, ResizeMode};
 use crate::Equivalent;
 
-use seize::{AsLink, Collector, Link, LocalGuard, OwnedGuard};
-use utils::{MapGuard, VerifiedGuard};
+use seize::{Collector, LocalGuard, OwnedGuard};
+use utils::{MapGuard, Stack, VerifiedGuard};
 
 /// A lock-free hash-table.
 pub struct HashMap<K, V, S> {
@@ -23,10 +24,7 @@ pub struct HashMap<K, V, S> {
     table: AtomicPtr<RawTable<Entry<K, V>>>,
 
     /// Collector for memory reclamation.
-    ///
-    /// The collector is allocated at the root and shared within each table
-    /// allocation in case it needs to be accessed during reclamation.
-    collector: Shared<Collector>,
+    collector: Collector,
 
     /// The resize mode, either blocking or incremental.
     resize: ResizeMode,
@@ -60,10 +58,7 @@ pub struct State<T> {
     pub parker: Parker,
 
     /// Entries whose retirement has been deferred by later tables.
-    pub deferred: seize::Deferred,
-
-    /// A pointer to the root collector, valid as long as the map is alive.
-    pub collector: *const Collector,
+    pub deferred: Stack<*mut T>,
 }
 
 impl<T> Default for State<T> {
@@ -75,8 +70,7 @@ impl<T> Default for State<T> {
             claim: AtomicUsize::new(0),
             status: AtomicU8::new(State::PENDING),
             parker: Parker::default(),
-            deferred: seize::Deferred::new(),
-            collector: ptr::null(),
+            deferred: Stack::new(),
         }
     }
 }
@@ -122,19 +116,12 @@ pub enum RawInsertResult<'g, K, V> {
 // An entry in the hash-table.
 #[repr(C)]
 pub struct Entry<K, V> {
-    /// A link to the `seize::Collector`, enabling garbage collection
-    /// when the entry is removed or replaced.
-    pub link: Link,
-
     /// The key for this entry.
     pub key: K,
 
     /// The value for this entry.
     pub value: V,
 }
-
-/// Safety: `Entry` is `repr(C)` and `seize::Link` is its first field.
-unsafe impl<K, V> AsLink for Entry<K, V> {}
 
 impl Entry<(), ()> {
     /// The entry is being copied to the new table, no updates are allowed on the old table.
@@ -158,18 +145,6 @@ impl Entry<(), ()> {
     ///
     /// In blocking mode this is unused.
     const BORROWED: usize = 0b100;
-
-    /// Reclaims an entry.
-    ///
-    /// # Safety
-    ///
-    /// The retired pointer must have been a valid pointer of type `*mut Entry<K, V>`.
-    #[inline]
-    unsafe fn reclaim<K, V>(link: *mut Link) {
-        let entry: *mut Entry<K, V> = link.cast();
-        // Safety: The caller guarantees that the pointer is valid.
-        let _entry = unsafe { Box::from_raw(entry) };
-    }
 }
 
 impl<K, V> utils::Unpack for Entry<K, V> {
@@ -239,8 +214,6 @@ impl<K, V, S> HashMap<K, V, S> {
         collector: Collector,
         resize: ResizeMode,
     ) -> HashMap<K, V, S> {
-        let collector = Shared::from(collector);
-
         // The table is lazily allocated.
         if capacity == 0 {
             return HashMap {
@@ -253,7 +226,7 @@ impl<K, V, S> HashMap<K, V, S> {
         }
 
         // Initialize the table and mark it as the root.
-        let mut table = Table::alloc(probe::entries_for(capacity), &collector);
+        let mut table = Table::alloc(probe::entries_for(capacity));
         *table.state_mut().status.get_mut() = State::PROMOTED;
 
         HashMap {
@@ -283,8 +256,9 @@ impl<K, V, S> HashMap<K, V, S> {
     where
         G: seize::Guard,
     {
-        assert!(
-            guard.belongs_to(&self.collector),
+        assert_eq!(
+            *guard.collector(),
+            self.collector,
             "Attempted to access map with incorrect guard"
         );
 
@@ -355,8 +329,9 @@ where
 
                 if meta == h2 {
                     // Load the full entry.
+                    //
+                    // Safety: `probe.i` is always in-bounds for the table length.
                     let entry = guard
-                        // Safety: `probe.i` is always in-bounds for the table length.
                         .protect(unsafe { table.entry(probe.i) }, Ordering::Acquire)
                         .unpack();
 
@@ -429,9 +404,7 @@ where
             // Inserted a new entry.
             RawInsertResult::Inserted(value) => {
                 // Increment the table length.
-                self.count
-                    .get(guard.thread_id())
-                    .fetch_add(1, Ordering::Relaxed);
+                self.count.get(guard).fetch_add(1, Ordering::Relaxed);
 
                 InsertResult::Inserted(value)
             }
@@ -464,11 +437,7 @@ where
         guard: &'g impl VerifiedGuard,
     ) -> RawInsertResult<'g, K, V> {
         // Allocate the entry to be inserted.
-        let new_entry = untagged(Box::into_raw(Box::new(Entry {
-            key,
-            value,
-            link: self.collector.link(),
-        })));
+        let new_entry = untagged(Box::into_raw(Box::new(Entry { key, value })));
 
         // Safety: We just allocated the entry above.
         let new_ref = unsafe { &(*new_entry.ptr) };
@@ -525,8 +494,9 @@ where
                 // Found a potential match.
                 else if meta == h2 {
                     // Load the full entry.
+                    //
+                    // Safety: `probe.i` is always in-bounds for the table length.
                     let entry = guard
-                        // Safety: `probe.i` is always in-bounds for the table length.
                         .protect(unsafe { table.entry(probe.i) }, Ordering::Acquire)
                         .unpack();
 
@@ -724,8 +694,9 @@ where
                 }
 
                 // Load the full entry.
+                //
+                // Safety: `probe.i` is always in-bounds for the table length.
                 let mut entry = guard
-                    // Safety: `probe.i` is always in-bounds for the table length.
                     .protect(unsafe { table.entry(probe.i) }, Ordering::Acquire)
                     .unpack();
 
@@ -775,8 +746,7 @@ where
                             };
 
                             // Decrement the table length.
-                            let count = self.count.get(guard.thread_id());
-                            count.fetch_sub(1, Ordering::Relaxed);
+                            self.count.get(guard).fetch_sub(1, Ordering::Relaxed);
 
                             // Safety: `entry` is a valid non-null entry that we found in the map
                             // before replacing it.
@@ -878,7 +848,8 @@ where
         let meta_entry = unsafe { table.meta(i) };
 
         // Try to claim the empty entry.
-        let found = match entry.compare_exchange(
+        let found = match guard.compare_exchange(
+            entry,
             ptr::null_mut(),
             new_entry,
             Ordering::Release,
@@ -899,28 +870,17 @@ where
 
         let (meta, status) = match EntryStatus::from(found) {
             EntryStatus::Value(_) | EntryStatus::Copied(_) => {
-                // Protect the entry before accessing it.
-                let found = guard.protect(entry, Ordering::Acquire).unpack();
+                // Safety: We performed a protected load of the pointer using a verified guard
+                // with `Acquire` and ensured that it is non-null, meaning it is valid for reads
+                // as long as we hold the guard.
+                let key = unsafe { &(*found.ptr).key };
 
-                // Re-check the entry status.
-                match EntryStatus::from(found) {
-                    EntryStatus::Value(found) | EntryStatus::Copied(found) => {
-                        // Safety: We performed a protected load of the pointer using a verified guard
-                        // with `Acquire` and ensured that it is non-null, meaning it is valid for reads
-                        // as long as we hold the guard.
-                        let key = unsafe { &(*found.ptr).key };
-
-                        // An entry was inserted, we have to hash it to get the metadata.
-                        //
-                        // The logic is the same for copied entries here as we have to
-                        // check if the key matches and continue the update in the new table.
-                        let hash = self.hasher.hash_one(key);
-                        (meta::h2(hash), EntryStatus::Value(found))
-                    }
-
-                    // The entry was deleted or null copied.
-                    EntryStatus::Null => (meta::TOMBSTONE, EntryStatus::Null),
-                }
+                // An entry was inserted, we have to hash it to get the metadata.
+                //
+                // The logic is the same for copied entries here as we have to
+                // check if the key matches and continue the update in the new table.
+                let hash = self.hasher.hash_one(key);
+                (meta::h2(hash), EntryStatus::Value(found))
             }
 
             // The entry was deleted or null copied.
@@ -958,7 +918,8 @@ where
         let entry = unsafe { table.entry(i) };
 
         // Try to perform the update.
-        let found = match entry.compare_exchange_weak(
+        let found = match guard.compare_exchange_weak(
+            entry,
             current.raw,
             new_entry,
             Ordering::Release,
@@ -978,26 +939,7 @@ where
             Err(found) => found.unpack(),
         };
 
-        let status = match EntryStatus::from(found) {
-            EntryStatus::Value(_) => {
-                // Protect the entry before accessing it.
-                let found = guard.protect(entry, Ordering::Acquire).unpack();
-
-                // Re-check the entry status.
-                EntryStatus::from(found)
-            }
-
-            // The entry was copied.
-            //
-            // We don't need to protect the entry as we never access it,
-            // we wait for it to be copied and continue in the new table.
-            EntryStatus::Copied(entry) => EntryStatus::Copied(entry),
-
-            // The entry was deleted.
-            removed => removed,
-        };
-
-        UpdateStatus::Found(status)
+        UpdateStatus::Found(EntryStatus::from(found))
     }
 
     /// Reserve capacity for `additional` more elements.
@@ -1049,8 +991,9 @@ where
 
             'probe: for i in 0..table.len() {
                 // Load the entry to delete.
+                //
+                // Safety: `i` is in bounds for the table length.
                 let mut entry = guard
-                    // Safety: `i` is in bounds for the table length.
                     .protect(unsafe { table.entry(i) }, Ordering::Acquire)
                     .unpack();
 
@@ -1088,8 +1031,7 @@ where
                             unsafe { table.meta(i).store(meta::TOMBSTONE, Ordering::Release) };
 
                             // Decrement the table length.
-                            let count = self.count.get(guard.thread_id());
-                            count.fetch_sub(1, Ordering::Relaxed);
+                            self.count.get(guard).fetch_sub(1, Ordering::Relaxed);
 
                             // Safety: The caller guarantees that `current` is a valid non-null entry that was
                             // inserted into the map. Additionally, it is now unreachable from this table due
@@ -1148,8 +1090,9 @@ where
                 }
 
                 // Load the entry to delete.
+                //
+                // Safety: `i` is in bounds for the table length.
                 let mut entry = guard
-                    // Safety: `i` is in bounds for the table length.
                     .protect(unsafe { table.entry(i) }, Ordering::Acquire)
                     .unpack();
 
@@ -1197,8 +1140,7 @@ where
                             unsafe { table.meta(i).store(meta::TOMBSTONE, Ordering::Release) };
 
                             // Decrement the table length.
-                            let count = self.count.get(guard.thread_id());
-                            count.fetch_sub(1, Ordering::Relaxed);
+                            self.count.get(guard).fetch_sub(1, Ordering::Relaxed);
 
                             // Safety: The caller guarantees that `current` is a valid non-null entry that was
                             // inserted into the map. Additionally, it is now unreachable from this table due
@@ -1372,7 +1314,7 @@ impl<K, V> LazyEntry<K, V> {
     /// Initializes the entry if it has not already been initialized, returning the pointer
     /// to the entry allocation.
     #[inline]
-    fn init(&mut self, collector: &Collector) -> *mut Entry<K, MaybeUninit<V>> {
+    fn init(&mut self) -> *mut Entry<K, MaybeUninit<V>> {
         match self {
             LazyEntry::Init(entry) => *entry,
             LazyEntry::Uninit(key) => {
@@ -1383,7 +1325,6 @@ impl<K, V> LazyEntry<K, V> {
                     let key = ptr::read(key);
                     let entry = panic::catch_unwind(panic::AssertUnwindSafe(|| {
                         Box::into_raw(Box::new(Entry {
-                            link: collector.link(),
                             value: MaybeUninit::uninit(),
                             key,
                         }))
@@ -1619,8 +1560,7 @@ where
                         Operation::Abort(value) => return Compute::Aborted(value),
                     };
 
-                    let new_entry = new_entry.init(&self.collector);
-
+                    let new_entry = new_entry.init();
                     // Safety: `new_entry` was just allocated above and is valid for writes.
                     unsafe { (*new_entry).value = MaybeUninit::new(value) }
 
@@ -1632,8 +1572,7 @@ where
                         // Successfully inserted.
                         InsertStatus::Inserted => {
                             // Increment the table length.
-                            let count = self.count.get(guard.thread_id());
-                            count.fetch_add(1, Ordering::Relaxed);
+                            self.count.get(guard).fetch_add(1, Ordering::Relaxed);
 
                             // Safety: `new_entry` was initialized above.
                             let new_ref = unsafe { &*new_entry.cast::<Entry<K, V>>() };
@@ -1673,8 +1612,9 @@ where
                 // Found a potential match.
                 else if meta == h2 {
                     // Load the full entry.
+                    //
+                    // Safety: `probe.i` is always in-bounds for the table length.
                     let found = guard
-                        // Safety: `probe.i` is always in-bounds for the table length.
                         .protect(unsafe { table.entry(probe.i) }, Ordering::Acquire)
                         .unpack();
 
@@ -1718,7 +1658,7 @@ where
 
                         // Update the value.
                         Operation::Insert(value) => {
-                            let new_entry = new_entry.init(&self.collector);
+                            let new_entry = new_entry.init();
 
                             // Safety: `new_entry` was just allocated above and is valid for writes.
                             unsafe { (*new_entry).value = MaybeUninit::new(value) }
@@ -1789,8 +1729,7 @@ where
                                     };
 
                                     // Decrement the table length.
-                                    let count = self.count.get(guard.thread_id());
-                                    count.fetch_sub(1, Ordering::Relaxed);
+                                    self.count.get(guard).fetch_sub(1, Ordering::Relaxed);
 
                                     // Safety: `entry` is a valid non-null entry that we found in the map
                                     // before replacing it.
@@ -1878,7 +1817,7 @@ where
         const CAPACITY: usize = 32;
 
         // Allocate the table and mark it as the root.
-        let mut new = Table::alloc(capacity.unwrap_or(CAPACITY), &self.collector);
+        let mut new = Table::alloc(capacity.unwrap_or(CAPACITY));
         *new.state_mut().status.get_mut() = State::PROMOTED;
 
         // Race to write the initial table.
@@ -1982,7 +1921,7 @@ where
         );
 
         // Allocate the new table while holding the lock.
-        let next = Table::alloc(next_capacity, &self.collector);
+        let next = Table::alloc(next_capacity);
         state.next.store(next.raw, Ordering::Release);
         drop(_allocating);
 
@@ -2151,6 +2090,10 @@ where
         // Mark the entry as copying.
         //
         // Safety: The caller guarantees that the index is in-bounds.
+        //
+        // Note that we don't need to protect the returned entry here, because
+        // no one is allowed to retire the entry once we put the `COPYING` bit
+        // down until it is inserted into the new table.
         let entry = unsafe { table.entry(i) }
             .fetch_or(Entry::COPYING, Ordering::AcqRel)
             .unpack();
@@ -2375,7 +2318,8 @@ where
                     let entry = unsafe { table.entry(probe.i) };
 
                     // Try to claim the entry.
-                    match entry.compare_exchange(
+                    match guard.compare_exchange(
+                        entry,
                         ptr::null_mut(),
                         new_entry.raw,
                         Ordering::Release,
@@ -2388,26 +2332,20 @@ where
                             return Some((table, probe.i));
                         }
                         Err(found) => {
+                            let found = found.unpack();
+
                             // The entry was deleted or copied.
-                            let meta = if found.unpack().ptr.is_null() {
+                            let meta = if found.ptr.is_null() {
                                 meta::TOMBSTONE
                             } else {
-                                // Protect the entry before accessing it.
-                                let found = guard.protect(entry, Ordering::Acquire).unpack();
+                                // Safety: We performed a protected load of the pointer using a verified guard with
+                                // `Acquire` and ensured that it is non-null, meaning it is valid for reads as long
+                                // as we hold the guard.
+                                let found_ref = unsafe { &(*found.ptr) };
 
-                                // Recheck the pointer.
-                                if found.ptr.is_null() {
-                                    meta::TOMBSTONE
-                                } else {
-                                    // Safety: We performed a protected load of the pointer using a verified guard with
-                                    // `Acquire` and ensured that it is non-null, meaning it is valid for reads as long
-                                    // as we hold the guard.
-                                    let found_ref = unsafe { &(*found.ptr) };
-
-                                    // Ensure the meta table is updated to avoid breaking the probe chain.
-                                    let hash = self.hasher.hash_one(&found_ref.key);
-                                    meta::h2(hash)
-                                }
+                                // Ensure the meta table is updated to avoid breaking the probe chain.
+                                let hash = self.hasher.hash_one(&found_ref.key);
+                                meta::h2(hash)
                             };
 
                             if meta_entry.load(Ordering::Relaxed) == meta::EMPTY {
@@ -2469,16 +2407,14 @@ where
 
                     // Retire the old table.
                     //
-                    // Safety: `table.raw` is a valid pointer to the table we just
-                    // copied from. Additionally, the CAS above made the previous table
-                    // unreachable from the root pointer, allowing it to be safely retired.
+                    // Safety: `table.raw` is a valid pointer to the table we just copied from.
+                    // Additionally, the CAS above made the previous table unreachable from the
+                    // root pointer, allowing it to be safely retired.
                     unsafe {
-                        guard.defer_retire(table.raw, |link| {
-                            let raw: *mut RawTable<Entry<K, V>> = link.cast();
-
+                        guard.defer_retire(table.raw, |table, collector| {
                             // Note that we do not drop entries because they have been copied to
                             // the new root.
-                            drop_table(Table::from_raw(raw));
+                            drop_table(Table::from_raw(table), collector);
                         });
                     }
                 }
@@ -2564,14 +2500,14 @@ where
             // Safety: In blocking resize mode, we only ever write to the root table, so the entry
             // is inaccessible from all tables.
             ResizeMode::Blocking => unsafe {
-                guard.defer_retire(entry.ptr, Entry::reclaim::<K, V>);
+                guard.defer_retire(entry.ptr, seize::reclaim::boxed);
             },
             // In incremental resize mode, the entry may be accessible in previous tables.
             ResizeMode::Incremental(_) => {
                 if entry.tag() & Entry::BORROWED == 0 {
                     // Safety: If the entry is not borrowed, meaning it is not in any previous tables,
                     // it is inaccessible even if the current table is not root. Thus we can safely retire.
-                    unsafe { guard.defer_retire(entry.ptr, Entry::reclaim::<K, V>) };
+                    unsafe { guard.defer_retire(entry.ptr, seize::reclaim::boxed) };
                     return;
                 }
 
@@ -2583,7 +2519,7 @@ where
                     if table.raw == root.raw {
                         // Safety: The root table is our table or a table that succeeds ours.
                         // Thus any previous tables are unreachable from the root, so we can safely retire.
-                        unsafe { guard.defer_retire(entry.ptr, Entry::reclaim::<K, V>) };
+                        unsafe { guard.defer_retire(entry.ptr, seize::reclaim::boxed) };
                         return;
                     }
 
@@ -2600,9 +2536,7 @@ where
 
                     // Defer the entry to be retired by the table we are copying from.
                     if next.raw == table.raw {
-                        // Safety: The caller guarantees that this method will not be
-                        // called multiple times with the same entry.
-                        unsafe { prev.state().deferred.defer(entry.ptr) };
+                        prev.state().deferred.push(entry.ptr);
                         return;
                     }
 
@@ -2651,9 +2585,10 @@ where
             }
 
             // Load the entry.
+            //
+            // Safety: We verified that `self.i` is in-bounds above.
             let entry = self
                 .guard
-                // Safety: We verified that `self.i` is in-bounds above.
                 .protect(unsafe { self.table.entry(self.i) }, Ordering::Acquire)
                 .unpack();
 
@@ -2735,7 +2670,7 @@ impl<K, V, S> Drop for HashMap<K, V, S> {
 
             // Safety: We have unique access to the table and do
             // not access it after this call.
-            unsafe { drop_table(table) };
+            unsafe { drop_table(table, &self.collector) };
 
             // Continue for all nested tables.
             raw = next;
@@ -2764,7 +2699,7 @@ unsafe fn drop_entries<K, V>(table: Table<Entry<K, V>>) {
         // not be accessed after this call. Additionally, we ensured
         // that the entry is not copied to avoid double freeing entries
         // that may exist in multiple tables.
-        unsafe { Entry::reclaim::<K, V>(entry.ptr.cast()) }
+        unsafe { drop(Box::from_raw(entry.ptr)) }
     }
 }
 
@@ -2773,12 +2708,7 @@ unsafe fn drop_entries<K, V>(table: Table<Entry<K, V>>) {
 // # Safety
 //
 // The table must not be accessed after this call.
-unsafe fn drop_table<K, V>(mut table: Table<Entry<K, V>>) {
-    // Safety: `drop_table` is either being called from `reclaim_all` in `Drop`
-    // or the table is being reclaimed by our thread. In both cases, the collector
-    // is still alive and safe to access through the state pointer.
-    let collector = unsafe { &*table.state().collector };
-
+unsafe fn drop_table<K, V>(mut table: Table<Entry<K, V>>, collector: &Collector) {
     // Drop any entries that were deferred during an incremental resize.
     //
     // Safety: Entries are deferred after they are made unreachable from the
@@ -2788,12 +2718,10 @@ unsafe fn drop_table<K, V>(mut table: Table<Entry<K, V>>) {
     // this table to have been retired, it also must no longer be accessible from the root,
     // meaning that the entry has been totally removed from the map, and can be safely
     // retired.
-    unsafe {
-        table
-            .state_mut()
-            .deferred
-            .retire_all(collector, Entry::reclaim::<K, V>)
-    }
+    table
+        .state_mut()
+        .deferred
+        .drain(|entry| unsafe { collector.retire(entry, seize::reclaim::boxed) });
 
     // Deallocate the table.
     //

--- a/src/raw/utils/counter.rs
+++ b/src/raw/utils/counter.rs
@@ -1,0 +1,54 @@
+use std::sync::atomic::{AtomicIsize, Ordering};
+
+use super::CachePadded;
+
+// A sharded atomic counter.
+//
+// Sharding the length counter of `HashMap` is extremely important,
+// as a single point of contention for insertions/deletions significantly
+// degrades concurrent performance.
+//
+// We can take advantage of the fact that `seize::Guard`
+pub struct Counter(Box<[CachePadded<AtomicIsize>]>);
+
+impl Default for Counter {
+    /// Create a new `Counter`.
+    fn default() -> Counter {
+        let num_cpus = std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1);
+
+        // Round up to the next power-of-two for fast modulo.
+        let shards = (0..num_cpus.next_power_of_two())
+            .map(|_| Default::default())
+            .collect();
+
+        Counter(shards)
+    }
+}
+
+impl Counter {
+    // Return the shard for the given thread ID.
+    #[inline]
+    pub fn get(&self, guard: &impl seize::Guard) -> &AtomicIsize {
+        // Guard thread IDs are essentially perfectly sharded due to
+        // the internal thread ID allocator, which makes contention
+        // very unlikely even with the exact number of shards as CPUs.
+        let shard = guard.thread_id() & (self.0.len() - 1);
+
+        &self.0[shard].value
+    }
+
+    // Returns the sum of all counter shards.
+    #[inline]
+    pub fn sum(&self) -> usize {
+        self.0
+            .iter()
+            .map(|x| x.value.load(Ordering::Relaxed))
+            .sum::<isize>()
+            .try_into()
+            // Depending on the order of deletion/insertions this might be negative,
+            // in which case we assume the map is empty.
+            .unwrap_or(0)
+    }
+}

--- a/src/raw/utils/mod.rs
+++ b/src/raw/utils/mod.rs
@@ -1,240 +1,12 @@
+mod counter;
 mod parker;
+mod stack;
+mod tagged;
+
+pub use counter::Counter;
 pub use parker::Parker;
-
-use std::ops::Deref;
-use std::ptr::NonNull;
-use std::sync::atomic::{AtomicIsize, AtomicPtr, Ordering};
-
-// Polyfill for the unstable strict-provenance APIs.
-#[allow(clippy::missing_safety_doc)]
-#[allow(dead_code)] // `strict_provenance` has stabilized on nightly.
-pub unsafe trait StrictProvenance<T>: Sized {
-    fn addr(self) -> usize;
-    fn map_addr(self, f: impl FnOnce(usize) -> usize) -> Self;
-    fn unpack(self) -> Tagged<T>
-    where
-        T: Unpack;
-}
-
-// Unpack a tagged pointer.
-pub trait Unpack {
-    // A mask for the pointer tag bits.
-    const MASK: usize;
-}
-
-unsafe impl<T> StrictProvenance<T> for *mut T {
-    #[inline(always)]
-    fn addr(self) -> usize {
-        self as usize
-    }
-
-    #[inline(always)]
-    fn map_addr(self, f: impl FnOnce(usize) -> usize) -> Self {
-        f(self.addr()) as Self
-    }
-
-    #[inline(always)]
-    fn unpack(self) -> Tagged<T>
-    where
-        T: Unpack,
-    {
-        Tagged {
-            raw: self,
-            ptr: self.map_addr(|addr| addr & T::MASK),
-        }
-    }
-}
-
-// An unpacked tagged pointer.
-pub struct Tagged<T> {
-    // The raw tagged pointer.
-    pub raw: *mut T,
-
-    // The untagged pointer.
-    pub ptr: *mut T,
-}
-
-// Creates a `Tagged` from an untagged pointer.
-#[inline]
-pub fn untagged<T>(value: *mut T) -> Tagged<T> {
-    Tagged {
-        raw: value,
-        ptr: value,
-    }
-}
-
-impl<T> Tagged<T>
-where
-    T: Unpack,
-{
-    // Returns the tag portion of this pointer.
-    #[inline]
-    pub fn tag(self) -> usize {
-        self.raw.addr() & !T::MASK
-    }
-
-    // Maps the tag of this pointer.
-    #[inline]
-    pub fn map_tag(self, f: impl FnOnce(usize) -> usize) -> Self {
-        Tagged {
-            raw: self.raw.map_addr(f),
-            ptr: self.ptr,
-        }
-    }
-}
-
-impl<T> Copy for Tagged<T> {}
-
-impl<T> Clone for Tagged<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-// Polyfill for the unstable `atomic_ptr_strict_provenance` APIs.
-pub trait AtomicPtrFetchOps<T> {
-    fn fetch_or(&self, value: usize, ordering: Ordering) -> *mut T;
-}
-
-impl<T> AtomicPtrFetchOps<T> for AtomicPtr<T> {
-    #[inline]
-    fn fetch_or(&self, value: usize, ordering: Ordering) -> *mut T {
-        #[cfg(not(miri))]
-        {
-            use std::sync::atomic::AtomicUsize;
-
-            // Safety: `AtomicPtr` and `AtomicUsize` are identical in terms
-            // of memory layout. This operation is technically invalid in that
-            // it loses provenance, but there is no stable alternative.
-            unsafe { &*(self as *const AtomicPtr<T> as *const AtomicUsize) }
-                .fetch_or(value, ordering) as *mut T
-        }
-
-        // Avoid ptr2int under Miri.
-        #[cfg(miri)]
-        {
-            // Returns the ordering for the read in an RMW operation.
-            const fn read_ordering(ordering: Ordering) -> Ordering {
-                match ordering {
-                    Ordering::SeqCst => Ordering::SeqCst,
-                    Ordering::AcqRel => Ordering::Acquire,
-                    _ => Ordering::Relaxed,
-                }
-            }
-
-            self.fetch_update(ordering, read_ordering(ordering), |ptr| {
-                Some(ptr.map_addr(|addr| addr | value))
-            })
-            .unwrap()
-        }
-    }
-}
-
-/// Pads and aligns a value to the length of a cache line.
-#[derive(Clone, Copy, Default, Hash, PartialEq, Eq)]
-// Source: https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-utils/src/cache_padded.rs#L63.
-#[cfg_attr(
-    any(
-        target_arch = "x86_64",
-        target_arch = "aarch64",
-        target_arch = "powerpc64",
-    ),
-    repr(align(128))
-)]
-#[cfg_attr(
-    any(
-        target_arch = "arm",
-        target_arch = "mips",
-        target_arch = "mips32r6",
-        target_arch = "mips64",
-        target_arch = "mips64r6",
-        target_arch = "riscv64",
-    ),
-    repr(align(32))
-)]
-#[cfg_attr(target_arch = "s390x", repr(align(256)))]
-#[cfg_attr(
-    not(any(
-        target_arch = "x86_64",
-        target_arch = "aarch64",
-        target_arch = "powerpc64",
-        target_arch = "arm",
-        target_arch = "mips",
-        target_arch = "mips32r6",
-        target_arch = "mips64",
-        target_arch = "mips64r6",
-        target_arch = "riscv64",
-        target_arch = "s390x",
-    )),
-    repr(align(64))
-)]
-pub struct CachePadded<T> {
-    value: T,
-}
-
-// A sharded atomic counter.
-pub struct Counter(Box<[CachePadded<AtomicIsize>]>);
-
-impl Default for Counter {
-    fn default() -> Counter {
-        let num_cpus = std::thread::available_parallelism()
-            .map(usize::from)
-            .unwrap_or(1);
-        let shards = (0..num_cpus.next_power_of_two())
-            .map(|_| Default::default())
-            .collect();
-        Counter(shards)
-    }
-}
-
-impl Counter {
-    // Return the shard for the given thread ID.
-    #[inline]
-    pub fn get(&self, thread: usize) -> &AtomicIsize {
-        &self.0[thread & (self.0.len() - 1)].value
-    }
-
-    // Returns the sum of all counter shards.
-    #[inline]
-    pub fn sum(&self) -> usize {
-        self.0
-            .iter()
-            .map(|x| x.value.load(Ordering::Relaxed))
-            .sum::<isize>()
-            .try_into()
-            // Depending on the order of deletion/insertions this might be negative,
-            // so assume the map is empty.
-            .unwrap_or(0)
-    }
-}
-
-// `Box<T>` but aliasable.
-pub struct Shared<T>(NonNull<T>);
-
-impl<T> From<T> for Shared<T> {
-    fn from(value: T) -> Shared<T> {
-        Shared(unsafe { NonNull::new_unchecked(Box::into_raw(Box::new(value))) })
-    }
-}
-
-impl<T> Deref for Shared<T> {
-    type Target = T;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        // Safety: `self.0` was allocated with `Box` and is never shared.
-        unsafe { &*self.0.as_ptr() }
-    }
-}
-
-impl<T> Drop for Shared<T> {
-    #[inline]
-    fn drop(&mut self) {
-        // Safety: `self.0` was allocated with `Box` and is never shared,
-        // and we have unique access to `self`.
-        let _ = unsafe { Box::from_raw(self.0.as_ptr()) };
-    }
-}
+pub use stack::Stack;
+pub use tagged::{untagged, AtomicPtrFetchOps, StrictProvenance, Tagged, Unpack};
 
 /// A `seize::Guard` that has been verified to belong to a given map.
 pub trait VerifiedGuard: seize::Guard {}
@@ -280,17 +52,8 @@ where
     }
 
     #[inline]
-    fn protect<T: seize::AsLink>(&self, ptr: &AtomicPtr<T>, ordering: Ordering) -> *mut T {
-        self.0.protect(ptr, ordering)
-    }
-
-    #[inline]
-    unsafe fn defer_retire<T: seize::AsLink>(
-        &self,
-        ptr: *mut T,
-        reclaim: unsafe fn(*mut seize::Link),
-    ) {
-        unsafe { self.0.defer_retire(ptr, reclaim) };
+    fn collector(&self) -> &seize::Collector {
+        self.0.collector()
     }
 
     #[inline]
@@ -299,12 +62,56 @@ where
     }
 
     #[inline]
-    fn belongs_to(&self, collector: &seize::Collector) -> bool {
-        self.0.belongs_to(collector)
+    unsafe fn defer_retire<T>(&self, ptr: *mut T, reclaim: unsafe fn(*mut T, &seize::Collector)) {
+        unsafe { self.0.defer_retire(ptr, reclaim) };
     }
+}
 
-    #[inline]
-    fn link(&self, collector: &seize::Collector) -> seize::Link {
-        self.0.link(collector)
-    }
+/// Pads and aligns a value to the length of a cache line.
+///
+// Source: https://github.com/crossbeam-rs/crossbeam/blob/0f81a6957588ddca9973e32e92e7e94abdad801e/crossbeam-utils/src/cache_padded.rs#L63.
+#[derive(Clone, Copy, Default, Hash, PartialEq, Eq)]
+#[cfg_attr(
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "arm64ec",
+        target_arch = "powerpc64",
+    ),
+    repr(align(128))
+)]
+#[cfg_attr(
+    any(
+        target_arch = "arm",
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6",
+        target_arch = "sparc",
+        target_arch = "hexagon",
+    ),
+    repr(align(32))
+)]
+#[cfg_attr(target_arch = "m68k", repr(align(16)))]
+#[cfg_attr(target_arch = "s390x", repr(align(256)))]
+#[cfg_attr(
+    not(any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "arm64ec",
+        target_arch = "powerpc64",
+        target_arch = "arm",
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6",
+        target_arch = "sparc",
+        target_arch = "hexagon",
+        target_arch = "m68k",
+        target_arch = "s390x",
+    )),
+    repr(align(64))
+)]
+pub struct CachePadded<T> {
+    value: T,
 }

--- a/src/raw/utils/parker.rs
+++ b/src/raw/utils/parker.rs
@@ -3,11 +3,12 @@ use std::sync::atomic::{AtomicPtr, AtomicU64, AtomicU8, Ordering};
 use std::sync::Mutex;
 use std::thread::{self, Thread};
 
-// A simpler thread parker.
+// A simple thread parker.
 //
-// This parker is rarely used and relatively naive. Ideally this would just use `futex`
-// but the hashmap needs to park on tagged pointer state, and mixed-sized atomic accesses
-// are questionable.
+// This parker is rarely used and relatively naive. Ideally this would just use a futex
+// but the hashmap needs to park on tagged pointer state so we would either need mixed-sized
+// atomic accesses (https://github.com/rust-lang/unsafe-code-guidelines/issues/345) which are
+// questionable, or 64 bit futexes, which are not available on most platforms.
 //
 // The parker implementation may be sharded and use intrusive lists if it is found to be
 // a bottleneck.

--- a/src/raw/utils/stack.rs
+++ b/src/raw/utils/stack.rs
@@ -1,0 +1,73 @@
+use std::ptr;
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+/// A simple lock-free, append-only, stack of pointers.
+///
+/// This stack is used to defer the reclamation of borrowed entries during
+/// an incremental resize, which is relatively rare.
+///
+/// Alternative, the deletion algorithm could traverse and delete the entry
+/// from previous tables to ensure it is unreachable from the root. However,
+/// it's not clear whether this is better than an allocation or even lock.
+pub struct Stack<T> {
+    head: AtomicPtr<Node<T>>,
+}
+
+struct Node<T> {
+    value: T,
+    next: *mut Node<T>,
+}
+
+impl<T> Stack<T> {
+    /// Create a new `Stack`.
+    pub fn new() -> Self {
+        Self {
+            head: AtomicPtr::new(ptr::null_mut()),
+        }
+    }
+
+    /// Add an entry to the stack.
+    pub fn push(&self, value: T) {
+        let node = Box::into_raw(Box::new(Node {
+            value,
+            next: ptr::null_mut(),
+        }));
+
+        loop {
+            // Load the head node.
+            //
+            // `Relaxed` is sufficient here as all reads are through `&mut self`.
+            let head = self.head.load(Ordering::Relaxed);
+
+            // Link the node to the stack.
+            unsafe { (*node).next = head }
+
+            // Attempt to push the node.
+            //
+            // `Relaxed` is similarly sufficient here.
+            if self
+                .head
+                .compare_exchange(head, node, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                break;
+            }
+        }
+    }
+
+    /// Drain all elements from the stack.
+    pub fn drain(&mut self, mut f: impl FnMut(T)) {
+        let mut head = *self.head.get_mut();
+
+        while !head.is_null() {
+            // Safety: We have `&mut self` and the node is non-null.
+            let owned_head = unsafe { Box::from_raw(head) };
+
+            // Drain the element.
+            f(owned_head.value);
+
+            // Continue iterating over the stack.
+            head = owned_head.next;
+        }
+    }
+}

--- a/src/raw/utils/tagged.rs
+++ b/src/raw/utils/tagged.rs
@@ -1,0 +1,126 @@
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+// Polyfill for the unstable strict-provenance APIs.
+#[allow(clippy::missing_safety_doc)]
+#[allow(dead_code)] // `strict_provenance` has stabilized on nightly.
+pub unsafe trait StrictProvenance<T>: Sized {
+    fn addr(self) -> usize;
+    fn map_addr(self, f: impl FnOnce(usize) -> usize) -> Self;
+    fn unpack(self) -> Tagged<T>
+    where
+        T: Unpack;
+}
+
+// Unpack a tagged pointer.
+pub trait Unpack {
+    // A mask for the pointer tag bits.
+    const MASK: usize;
+}
+
+unsafe impl<T> StrictProvenance<T> for *mut T {
+    #[inline(always)]
+    fn addr(self) -> usize {
+        self as usize
+    }
+
+    #[inline(always)]
+    fn map_addr(self, f: impl FnOnce(usize) -> usize) -> Self {
+        f(self.addr()) as Self
+    }
+
+    #[inline(always)]
+    fn unpack(self) -> Tagged<T>
+    where
+        T: Unpack,
+    {
+        Tagged {
+            raw: self,
+            ptr: self.map_addr(|addr| addr & T::MASK),
+        }
+    }
+}
+
+// An unpacked tagged pointer.
+pub struct Tagged<T> {
+    // The raw tagged pointer.
+    pub raw: *mut T,
+
+    // The untagged pointer.
+    pub ptr: *mut T,
+}
+
+// Creates a `Tagged` from an untagged pointer.
+#[inline]
+pub fn untagged<T>(value: *mut T) -> Tagged<T> {
+    Tagged {
+        raw: value,
+        ptr: value,
+    }
+}
+
+impl<T> Tagged<T>
+where
+    T: Unpack,
+{
+    // Returns the tag portion of this pointer.
+    #[inline]
+    pub fn tag(self) -> usize {
+        self.raw.addr() & !T::MASK
+    }
+
+    // Maps the tag of this pointer.
+    #[inline]
+    pub fn map_tag(self, f: impl FnOnce(usize) -> usize) -> Self {
+        Tagged {
+            raw: self.raw.map_addr(f),
+            ptr: self.ptr,
+        }
+    }
+}
+
+impl<T> Copy for Tagged<T> {}
+
+impl<T> Clone for Tagged<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+// Polyfill for the unstable `atomic_ptr_strict_provenance` APIs.
+pub trait AtomicPtrFetchOps<T> {
+    fn fetch_or(&self, value: usize, ordering: Ordering) -> *mut T;
+}
+
+impl<T> AtomicPtrFetchOps<T> for AtomicPtr<T> {
+    #[inline]
+    fn fetch_or(&self, value: usize, ordering: Ordering) -> *mut T {
+        #[cfg(not(miri))]
+        {
+            use std::sync::atomic::AtomicUsize;
+
+            // Safety: `AtomicPtr` and `AtomicUsize` are identical in terms
+            // of memory layout. This operation is technically invalid in that
+            // it loses provenance, but there is no stable alternative.
+            unsafe { &*(self as *const AtomicPtr<T> as *const AtomicUsize) }
+                .fetch_or(value, ordering) as *mut T
+        }
+
+        // Avoid ptr2int under Miri.
+        #[cfg(miri)]
+        {
+            // Returns the ordering for the read in an RMW operation.
+            const fn read_ordering(ordering: Ordering) -> Ordering {
+                match ordering {
+                    Ordering::SeqCst => Ordering::SeqCst,
+                    Ordering::AcqRel => Ordering::Acquire,
+                    _ => Ordering::Relaxed,
+                }
+            }
+
+            self.fetch_update(ordering, read_ordering(ordering), |ptr| {
+                Some(ptr.map_addr(|addr| addr | value))
+            })
+            .unwrap()
+        }
+    }
+}

--- a/src/set.rs
+++ b/src/set.rs
@@ -692,7 +692,7 @@ where
         let other = HashSet::builder()
             .capacity(self.len())
             .hasher(self.raw.hasher.clone())
-            .collector(self.raw.collector().clone())
+            .collector(seize::Collector::new())
             .build();
 
         {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -5,14 +5,14 @@ use seize::Collector;
 
 // Run the test on different configurations of a `HashMap`.
 pub fn with_map<K, V>(mut test: impl FnMut(&dyn Fn() -> HashMap<K, V>)) {
-    let collector = Collector::new().batch_size(128);
+    let collector = || Collector::new().batch_size(128);
 
     // Blocking resize mode.
     if !cfg!(papaya_stress) {
         test(
             &(|| {
                 HashMap::builder()
-                    .collector(collector.clone())
+                    .collector(collector())
                     .resize_mode(ResizeMode::Blocking)
                     .build()
             }),
@@ -23,7 +23,7 @@ pub fn with_map<K, V>(mut test: impl FnMut(&dyn Fn() -> HashMap<K, V>)) {
     test(
         &(|| {
             HashMap::builder()
-                .collector(collector.clone())
+                .collector(collector())
                 .resize_mode(ResizeMode::Incremental(1))
                 .build()
         }),
@@ -34,7 +34,7 @@ pub fn with_map<K, V>(mut test: impl FnMut(&dyn Fn() -> HashMap<K, V>)) {
     test(
         &(|| {
             HashMap::builder()
-                .collector(collector.clone())
+                .collector(collector())
                 .resize_mode(ResizeMode::Incremental(128))
                 .build()
         }),


### PR DESCRIPTION
Note that this is a breaking change.

Most of this is pretty straightforward and simplifies the existing code. We also see a ~10% performance improvement across the board and ~30% reduction in memory usage. The only real loss is of `seize::Deferred`. For now I've replaced this with a lock-free stack that allocates. Alternatively, instead of deferring retirement, we can go back and delete the entry from all previous tables to ensure it is unreachable. This seems pretty expensive, so I'm not sure it is worth it compared to an allocation or even a lock.