### PR TITLE
Fix invalid pointer dereference in `HashMap::retain`

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1152,7 +1152,7 @@ where
                     // Safety: We performed a protected load of the pointer using a verified guard with
                     // `Acquire` and ensured that it is non-null, meaning it is valid for reads as long
                     // as we hold the guard.
-                    let entry_ref = unsafe { &*entry.raw };
+                    let entry_ref = unsafe { &*entry.ptr };
 
                     // Should we retain this entry?
                     if f(&entry_ref.key, &entry_ref.value) {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -815,7 +815,7 @@ fn retain_empty() {
 fn retain_all_false() {
     with_map::<usize, usize>(|map| {
         let map = map();
-        for i in 0..10 {
+        for i in 0..100 {
             map.pin().insert(i, i);
         }
         map.pin().retain(|_, _| false);
@@ -827,11 +827,11 @@ fn retain_all_false() {
 fn retain_all_true() {
     with_map::<usize, usize>(|map| {
         let map = map();
-        for i in 0..10 {
+        for i in 0..100 {
             map.pin().insert(i, i);
         }
         map.pin().retain(|_, _| true);
-        assert_eq!(map.len(), 10);
+        assert_eq!(map.len(), 100);
     });
 }
 
@@ -839,14 +839,14 @@ fn retain_all_true() {
 fn retain_some() {
     with_map::<usize, usize>(|map| {
         let map = map();
-        for i in 0..10 {
+        for i in 0..100 {
             map.pin().insert(i, i);
         }
-        map.pin().retain(|_, v| *v >= 5);
+        map.pin().retain(|_, v| *v < 5);
         assert_eq!(map.len(), 5);
         let mut got: Vec<_> = map.pin().values().copied().collect();
         got.sort();
-        assert_eq!(got, [5, 6, 7, 8, 9]);
+        assert_eq!(got, [0, 1, 2, 3, 4]);
     });
 }
 

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -1051,7 +1051,10 @@ fn retain_stress() {
                 s.spawn(|| {
                     barrier.wait();
                     for _ in 0..(threads * 20) {
-                        map.pin().retain(|_, _| true);
+                        map.pin().retain(|k, v| {
+                            assert_eq!(k, v);
+                            true
+                        });
                     }
                 });
             });


### PR DESCRIPTION
Resolves https://github.com/ibraheemdev/papaya/issues/63.