### PR TITLE
Add rayon feature flag and implement IntoParIterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = ["assets/*"]
 equivalent = "1"
 seize = "0.5"
 serde = { version = "1", optional = true }
+rayon = { version = "1", optional = true }
 
 [dev-dependencies]
 rand = "0.8"
@@ -30,6 +31,7 @@ serde_json = "1"
 [features]
 default = []
 serde = ["dep:serde"]
+rayon = ["dep:rayon"]
 
 [profile.test]
 inherits = "release"

--- a/src/map.rs
+++ b/src/map.rs
@@ -1527,6 +1527,15 @@ where
         }
     }
 
+    /// Returns a parallel iterator over all key-value pairs.
+    ///
+    /// Requires the `rayon` feature.
+    #[cfg(feature = "rayon")]
+    #[inline]
+    pub fn par_iter(&self) -> raw::ParIter<'_, K, V, MapGuard<G>> {
+        self.map.raw.par_iter(&self.guard)
+    }
+
     /// An iterator visiting all keys in arbitrary order.
     /// The iterator element type is `&K`.
     ///
@@ -1569,6 +1578,22 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, K, V, S, G> rayon::iter::IntoParallelIterator for &'a HashMapRef<'_, K, V, S, G>
+where
+    K: Hash + Eq + Sync,
+    V: Sync,
+    S: BuildHasher,
+    G: Guard + Sync,
+{
+    type Item = (&'a K, &'a V);
+    type Iter = raw::ParIter<'a, K, V, MapGuard<G>>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.map.raw.par_iter(&self.guard)
     }
 }
 

--- a/src/raw/utils/mod.rs
+++ b/src/raw/utils/mod.rs
@@ -5,7 +5,9 @@ mod tagged;
 
 pub use counter::Counter;
 pub use parker::Parker;
+use seize::Guard as _;
 pub use stack::Stack;
+use std::fmt;
 pub use tagged::{untagged, AtomicPtrFetchOps, StrictProvenance, Tagged, Unpack};
 
 /// A `seize::Guard` that has been verified to belong to a given map.
@@ -13,6 +15,17 @@ pub trait VerifiedGuard: seize::Guard {}
 
 #[repr(transparent)]
 pub struct MapGuard<G>(G);
+
+impl<G> fmt::Debug for MapGuard<G>
+where
+    G: seize::Guard,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MapGuard")
+            .field("thread_id", &self.thread_id())
+            .finish()
+    }
+}
 
 impl<G> MapGuard<G> {
     /// Create a new `MapGuard`.

--- a/tests/rayon_iter.rs
+++ b/tests/rayon_iter.rs
@@ -1,0 +1,68 @@
+#![cfg(feature = "rayon")]
+
+use rayon::prelude::*;
+
+mod common;
+use common::{with_map, with_set};
+
+#[test]
+fn hashmap_par_iter() {
+    if cfg!(papaya_stress) {
+        return;
+    }
+    with_map::<usize, usize>(|map| {
+        let map = map();
+        let len = if cfg!(miri) { 100 } else { 10_000 };
+        for i in 0..len {
+            map.pin_owned().insert(i, i + 1);
+        }
+
+        let mut expected: Vec<_> = (0..len).map(|i| (i, i + 1)).collect();
+
+        let mut got: Vec<_> = map
+            .pin_owned()
+            .par_iter()
+            .map(|(&k, &v)| (k, v))
+            .collect();
+        got.sort();
+        expected.sort();
+        assert_eq!(expected, got);
+
+        let mut via_trait: Vec<_> = (&map.pin_owned())
+            .into_par_iter()
+            .map(|(&k, &v)| (k, v))
+            .collect();
+        via_trait.sort();
+        assert_eq!(expected, via_trait);
+    });
+}
+
+#[test]
+fn hashset_par_iter() {
+    if cfg!(papaya_stress) {
+        return;
+    }
+    with_set::<usize>(|set| {
+        let set = set();
+        let len = if cfg!(miri) { 100 } else { 10_000 };
+        for i in 0..len {
+            set.pin_owned().insert(i);
+        }
+
+        let mut expected: Vec<_> = (0..len).collect();
+
+        let mut got: Vec<_> = set
+            .pin_owned()
+            .par_iter()
+            .copied()
+            .collect();
+        got.sort();
+        expected.sort();
+        assert_eq!(expected, got);
+
+        let mut via_trait: Vec<_> = (&set.pin_owned()).into_par_iter().copied().collect();
+        via_trait.sort();
+        assert_eq!(expected, via_trait);
+    });
+}
+


### PR DESCRIPTION
This seems to solve my issue https://github.com/ibraheemdev/papaya/issues/47 asking for a faster way to iterate. In my use case, I'm building up a large map (in parallel), then I need to write the entire thing to parquet files as fast as possible, so consuming the map across threads works great. 

- Add a `rayon` feature flag to `Cargo.toml`.
- Add `IntoParIterator` and `par_iter` implementations for `HashSet` and `HashMap`.
- Add tests to show that the implementations don't lose any entries.

