### PR TITLE
Enforce minimum alignment on entries to fix tagged pointer unsoundness

### DIFF
--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -118,8 +118,9 @@ pub enum RawInsertResult<'g, K, V> {
     },
 }
 
-// An entry in the hash-table.
-#[repr(C)]
+// An entry in the hash-table. We force a minimum of 8-byte alignment because
+// we store entry flags in the low 3 bits of pointers to this type.
+#[repr(C, align(8))]
 pub struct Entry<K, V> {
     /// The key for this entry.
     pub key: K,

--- a/src/raw/utils/tagged.rs
+++ b/src/raw/utils/tagged.rs
@@ -33,6 +33,9 @@ unsafe impl<T> StrictProvenance<T> for *mut T {
     where
         T: Unpack,
     {
+        // This assert will fail at compile time if T doesn't have an alignment that
+        // guarantees all valid pointers have zero in the bits excluded by T::MASK.
+        const { assert!(align_of::<T>() > !T::MASK) };
         Tagged {
             raw: self,
             ptr: self.map_addr(|addr| addr & T::MASK),


### PR DESCRIPTION
The code currently assumes that it's safe to store tags in the low 3 bits of pointers to `raw::Entry<K, V>` values, which is only valid if those pointers are 8-byte aligned (otherwise the tags will overwrite real bits). But the `raw::Entry` type itself doesn't enforce any particular alignment besides those of its fields, and for example `raw::Entry<i32, i32>` only has 4-byte alignment on most systems.

However, most memory allocators have a larger minimum alignment, which hides the issue. On Linux, GNU libc [documents](https://www.gnu.org/software/libc/manual/html_node/Aligned-Memory-Blocks.html#:~:text=The%20address%20of%20a%20block%20returned%20by%20malloc%20or%20realloc%20in%20GNU%20systems%20is%20always%20a%20multiple%20of%20eight%20(or%20sixteen%20on%2064%2Dbit%20systems).) a minimum 8-byte alignment on all architectures, for example. I'm pretty sure this is why none of the tests in this repo caught it.

I found this bug after a long debugging process. I maintain a Zstandard library for Node.js that includes a native add-on, and I supply pre-built binaries which are tested in CI before publication. After upgrading to the recently-released version 30 of the [Jest JS testing framework](https://jestjs.io), I found that tests for the 32-bit Windows binaries crashed with an invalid memory access before my native code was even loaded. It turns out that Jest started using the Rust library [unrs-resolver](https://github.com/unrs/unrs-resolver), which uses papaya and mimalloc. On 32-bit platforms, mimalloc **can** return 4-byte-aligned pointers if the type alignment allows it, and if that happens the process pretty quickly goes up in flames.

The fix is easy enough: I added a `align(8)` flag to the `Entry` struct `repr` to enforce a minimum 8-byte alignment. This should have no effect on platforms where the allocator already enforces this alignment, and has no effect if the types already had 8+-byte alignment to start (it can't reduce alignment). 

I also added an assertion to the `tagged` utilities that blows up at compile time if the code would try to mask out more bits than the type alignment permits. If you add this assert without the above fix, the test suite triggers it in several files.