### PR TITLE
feat: add `drain` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,8 +236,8 @@ mod serde_impls;
 
 pub use equivalent::Equivalent;
 pub use map::{
-    Compute, HashMap, HashMapBuilder, HashMapRef, Iter, Keys, OccupiedError, Operation, ResizeMode,
-    Values,
+    Compute, Drain, HashMap, HashMapBuilder, HashMapRef, Iter, Keys, OccupiedError, Operation,
+    ResizeMode, Values,
 };
 pub use seize::{Guard, LocalGuard, OwnedGuard};
 pub use set::{HashSet, HashSetBuilder, HashSetRef};

--- a/src/raw/utils/mod.rs
+++ b/src/raw/utils/mod.rs
@@ -67,6 +67,12 @@ where
     }
 }
 
+impl<G> core::fmt::Debug for MapGuard<G> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MapGuard").finish()
+    }
+}
+
 /// Pads and aligns a value to the length of a cache line.
 ///
 // Source: https://github.com/crossbeam-rs/crossbeam/blob/0f81a6957588ddca9973e32e92e7e94abdad801e/crossbeam-utils/src/cache_padded.rs#L63.

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -31,6 +31,78 @@ fn clear() {
 }
 
 #[test]
+fn drain() {
+    with_map::<usize, usize>(|map| {
+        let map = map();
+        let guard = map.guard();
+
+        // Insert some values
+        map.insert(0, 10, &guard);
+        map.insert(1, 11, &guard);
+        map.insert(2, 12, &guard);
+        map.insert(3, 13, &guard);
+        map.insert(4, 14, &guard);
+
+        assert_eq!(map.len(), 5);
+
+        // Drain all values
+        let drained: Vec<_> = map.drain(&guard).collect();
+
+        // Map should be empty after drain
+        assert!(map.is_empty());
+        assert_eq!(map.len(), 0);
+
+        // Check that all values were drained
+        assert_eq!(drained.len(), 5);
+        assert!(drained.contains(&10));
+        assert!(drained.contains(&11));
+        assert!(drained.contains(&12));
+        assert!(drained.contains(&13));
+        assert!(drained.contains(&14));
+    });
+}
+
+#[test]
+fn drain_empty() {
+    with_map::<usize, usize>(|map| {
+        let map = map();
+
+        // Drain empty map
+        let drained: Vec<_> = map.drain(&map.guard()).collect();
+
+        assert!(map.is_empty());
+        assert_eq!(drained.len(), 0);
+    });
+}
+
+#[test]
+fn drain_pinned() {
+    with_map::<usize, usize>(|map| {
+        let map = map();
+
+        // Insert some values using pinned API
+        map.pin().insert(0, 100);
+        map.pin().insert(1, 200);
+        map.pin().insert(2, 300);
+
+        assert_eq!(map.len(), 3);
+
+        // Drain all values using pinned API
+        let drained: Vec<_> = map.pin().drain().collect();
+
+        // Map should be empty after drain
+        assert!(map.is_empty());
+        assert_eq!(map.len(), 0);
+
+        // Check that all values were drained
+        assert_eq!(drained.len(), 3);
+        assert!(drained.contains(&100));
+        assert!(drained.contains(&200));
+        assert!(drained.contains(&300));
+    });
+}
+
+#[test]
 fn insert() {
     with_map::<usize, usize>(|map| {
         let map = map();


### PR DESCRIPTION
WIP

Adds a method to drain the map with an iterator.

Needs more testing (what happens with deletions while iterating, etc.)

I also think the resize logic is probably wrong because it could maybe lead to elements being seen twice