### PR TITLE
Allow shared `Arc<Collector>` usage

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -96,8 +96,8 @@ where
     /// This method may be useful when you wish to utilize a single [`seize::Collector`] across
     /// multiple maps contained in a single structure.
     ///
-    /// Note that the entries in the map will not be reclaimed until the `Arc<seize::Collector>`,
-    /// is dropped and so may outlive the lifetime of the map.
+    /// Note that the entries in the map will not be reclaimed until the `Arc<seize::Collector>`
+    /// is dropped, and so may outlive the lifetime of the map.
     pub fn shared_collector(self, collector: Arc<Collector>) -> HashMapBuilder<K, V, S> {
         HashMapBuilder {
             collector,

--- a/src/map.rs
+++ b/src/map.rs
@@ -30,10 +30,10 @@ unsafe impl<K: Send, V: Send, S: Send> Send for HashMap<K, V, S> {}
 // on a different thread than they were created on through shared access to the
 // `HashMap`.
 //
-// Additionally, `HashMap` owns its `seize::Collector` and never exposes it,
-// so multiple threads cannot be involved in reclamation without sharing the
-// `HashMap` itself. If this was not true, we would require stricter bounds
-// on `HashMap` operations themselves.
+// Additionally, `HashMap` owns its `seize::Collector` except when the `shared_collector`
+// method is used, which enforces a stricter `{K, V}: Send + 'static` bound directly, as
+// it allows multiple threads to participate in reclamation without ever sharing the `HashMap`
+// itself, and allows keys and values to outlive the lifetime of the map.
 unsafe impl<K: Send + Sync, V: Send + Sync, S: Sync> Sync for HashMap<K, V, S> {}
 
 /// A builder for a [`HashMap`].

--- a/src/map.rs
+++ b/src/map.rs
@@ -3,7 +3,6 @@ use crate::raw::{self, InsertResult};
 use crate::Equivalent;
 use seize::{Collector, Guard, LocalGuard, OwnedGuard};
 
-use std::borrow::Borrow;
 use std::collections::hash_map::RandomState;
 use std::fmt;
 use std::hash::{BuildHasher, Hash};
@@ -15,17 +14,14 @@ use std::sync::Arc;
 /// Most hash table operations require a [`Guard`](crate::Guard), which can be acquired through
 /// [`HashMap::guard`] or using the [`HashMap::pin`] API. See the [crate-level documentation](crate#usage)
 /// for details.
-pub struct HashMap<K, V, S = RandomState, C = Collector>
-where
-    C: Borrow<Collector>,
-{
-    raw: raw::HashMap<K, V, S, C>,
+pub struct HashMap<K, V, S = RandomState> {
+    raw: raw::HashMap<K, V, S>,
 }
 
 // Safety: `HashMap` acts as a single-threaded collection on a single thread.
 // References to keys and values cannot outlive the map's lifetime on a given
 // thread.
-unsafe impl<K: Send, V: Send, S: Send, C: Send + Borrow<Collector>> Send for HashMap<K, V, S, C> {}
+unsafe impl<K: Send, V: Send, S: Send> Send for HashMap<K, V, S> {}
 
 // Safety: We only ever hand out `&{K, V}` through shared references to the map,
 // and never `&mut {K, V}` except through synchronized memory reclamation.
@@ -38,7 +34,7 @@ unsafe impl<K: Send, V: Send, S: Send, C: Send + Borrow<Collector>> Send for Has
 // so multiple threads cannot be involved in reclamation without sharing the
 // `HashMap` itself. If this was not true, we would require stricter bounds
 // on `HashMap` operations themselves.
-unsafe impl<K: Send + Sync, V: Send + Sync, S: Sync, C: Sync + Borrow<Collector>> Sync for HashMap<K, V, S, C> {}
+unsafe impl<K: Send + Sync, V: Send + Sync, S: Sync> Sync for HashMap<K, V, S> {}
 
 /// A builder for a [`HashMap`].
 ///
@@ -61,13 +57,10 @@ unsafe impl<K: Send + Sync, V: Send + Sync, S: Sync, C: Sync + Borrow<Collector>
 ///     // Construct the hash map.
 ///     .build();
 /// ```
-pub struct HashMapBuilder<K, V, S = RandomState, C = Collector>
-where
-    C: Borrow<Collector>,
-{
+pub struct HashMapBuilder<K, V, S = RandomState> {
     hasher: S,
     capacity: usize,
-    collector: C,
+    collector: Arc<Collector>,
     resize_mode: ResizeMode,
     _kv: PhantomData<(K, V)>,
 }
@@ -93,23 +86,6 @@ impl<K, V> HashMapBuilder<K, V> {
     }
 }
 
-impl<K, V, S> HashMapBuilder<K, V, S> {
-    /// Set the [`seize::Collector`] used for garbage collection.
-    ///
-    /// This method may be useful when you want more control over garbage collection.
-    ///
-    /// Note that all `Guard` references used to access the map must be produced by
-    /// the provided `collector`.
-    pub fn collector(self, collector: Collector) -> HashMapBuilder<K, V, S> {
-        HashMapBuilder {
-            collector,
-            hasher: self.hasher,
-            capacity: self.capacity,
-            resize_mode: self.resize_mode,
-            _kv: PhantomData,
-        }
-    }
-}
 impl<K, V, S> HashMapBuilder<K, V, S>
 where
     K: Send + 'static,
@@ -122,10 +98,7 @@ where
     ///
     /// Note that to ensure the `HashMap` are reclaimed, the `Arc<seize::Collector>` must be dropped, so
     /// it should not be owned indefinitely.
-    pub fn shared_collector(
-        self,
-        collector: Arc<Collector>,
-    ) -> HashMapBuilder<K, V, S, Arc<Collector>> {
+    pub fn shared_collector(self, collector: Arc<Collector>) -> HashMapBuilder<K, V, S> {
         HashMapBuilder {
             collector,
             hasher: self.hasher,
@@ -136,16 +109,29 @@ where
     }
 }
 
-impl<K, V, S, C> HashMapBuilder<K, V, S, C>
-where
-    C: Borrow<Collector>,
-{
+impl<K, V, S> HashMapBuilder<K, V, S> {
+    /// Set the [`seize::Collector`] used for garbage collection.
+    ///
+    /// This method may be useful when you want more control over garbage collection.
+    ///
+    /// Note that all `Guard` references used to access the map must be produced by
+    /// the provided `collector`.
+    pub fn collector(self, collector: Collector) -> HashMapBuilder<K, V, S> {
+        HashMapBuilder {
+            collector: Arc::new(collector),
+            hasher: self.hasher,
+            capacity: self.capacity,
+            resize_mode: self.resize_mode,
+            _kv: PhantomData,
+        }
+    }
+
     /// Set the initial capacity of the map.
     ///
     /// The table should be able to hold at least `capacity` elements before resizing.
     /// However, the capacity is an estimate, and the table may prematurely resize due
     /// to poor hash distribution. If `capacity` is 0, the hash map will not allocate.
-    pub fn capacity(self, capacity: usize) -> HashMapBuilder<K, V, S, C> {
+    pub fn capacity(self, capacity: usize) -> HashMapBuilder<K, V, S> {
         HashMapBuilder {
             capacity,
             hasher: self.hasher,
@@ -167,7 +153,7 @@ where
     }
 
     /// Construct a [`HashMap`] from the builder, using the configured options.
-    pub fn build(self) -> HashMap<K, V, S, C> {
+    pub fn build(self) -> HashMap<K, V, S> {
         HashMap {
             raw: raw::HashMap::new(self.capacity, self.hasher, self.collector, self.resize_mode),
         }
@@ -237,7 +223,7 @@ impl<K, V> HashMap<K, V> {
     /// let map: HashMap<&str, i32> = HashMap::new();
     /// ```
     pub fn new() -> HashMap<K, V> {
-        HashMap::with_capacity_and_hasher(0, RandomState::default())
+        HashMap::with_capacity_and_hasher(0, RandomState::new())
     }
 
     /// Creates an empty `HashMap` with the specified capacity.
@@ -256,7 +242,7 @@ impl<K, V> HashMap<K, V> {
     /// let map: HashMap<&str, i32> = HashMap::with_capacity(10);
     /// ```
     pub fn with_capacity(capacity: usize) -> HashMap<K, V> {
-        HashMap::with_capacity_and_hasher(capacity, RandomState::default())
+        HashMap::with_capacity_and_hasher(capacity, RandomState::new())
     }
     /// Returns a builder for a `HashMap`.
     ///
@@ -266,7 +252,7 @@ impl<K, V> HashMap<K, V> {
         HashMapBuilder {
             capacity: 0,
             hasher: RandomState::default(),
-            collector: Collector::default(),
+            collector: Arc::new(Collector::new()),
             resize_mode: ResizeMode::default(),
             _kv: PhantomData,
         }
@@ -278,20 +264,6 @@ where
 {
     fn default() -> Self {
         HashMap::with_hasher(S::default())
-    }
-}
-
-impl<K, V, S> Default for HashMap<K, V, S, Arc<Collector>>
-where
-    S: Default,
-    K: Send + 'static,
-    V: Send + 'static,
-{
-    fn default() -> Self {
-        HashMap::builder()
-            .hasher(S::default())
-            .shared_collector(Arc::new(Collector::new()))
-            .build()
     }
 }
 
@@ -318,7 +290,7 @@ impl<K, V, S> HashMap<K, V, S> {
     /// map.pin().insert(1, 2);
     /// ```
     pub fn with_hasher(hash_builder: S) -> HashMap<K, V, S> {
-        HashMap::<K, V, S>::with_capacity_and_hasher(0, hash_builder)
+        HashMap::with_capacity_and_hasher(0, hash_builder)
     }
 
     /// Creates an empty `HashMap` with at least the specified capacity, using
@@ -341,7 +313,7 @@ impl<K, V, S> HashMap<K, V, S> {
     /// ```
     /// use papaya::HashMap;
     /// use std::hash::RandomState;
-    //
+    ///
     /// let s = RandomState::new();
     /// let map = HashMap::with_capacity_and_hasher(10, s);
     /// map.pin().insert(1, 2);
@@ -351,23 +323,18 @@ impl<K, V, S> HashMap<K, V, S> {
             raw: raw::HashMap::new(
                 capacity,
                 hash_builder,
-                Collector::default(),
+                Arc::new(Collector::new()),
                 ResizeMode::default(),
             ),
         }
     }
-}
 
-impl<K, V, S, C> HashMap<K, V, S, C>
-where
-    C: Borrow<Collector>,
-{
     /// Returns a pinned reference to the map.
     ///
     /// The returned reference manages a guard internally, preventing garbage collection
     /// for as long as it is held. See the [crate-level documentation](crate#usage) for details.
     #[inline]
-    pub fn pin(&self) -> HashMapRef<'_, K, V, S, C, LocalGuard<'_>> {
+    pub fn pin(&self) -> HashMapRef<'_, K, V, S, LocalGuard<'_>> {
         HashMapRef {
             guard: self.raw.guard(),
             map: self,
@@ -383,7 +350,7 @@ where
     /// The returned reference manages a guard internally, preventing garbage collection
     /// for as long as it is held. See the [crate-level documentation](crate#usage) for details.
     #[inline]
-    pub fn pin_owned(&self) -> HashMapRef<'_, K, V, S, C, OwnedGuard<'_>> {
+    pub fn pin_owned(&self) -> HashMapRef<'_, K, V, S, OwnedGuard<'_>> {
         HashMapRef {
             guard: self.raw.owned_guard(),
             map: self,
@@ -396,7 +363,7 @@ where
     /// See the [crate-level documentation](crate#usage) for details.
     #[inline]
     pub fn guard(&self) -> LocalGuard<'_> {
-        self.raw.collector().borrow().enter()
+        self.raw.collector().enter()
     }
 
     /// Returns an owned guard for use with this map.
@@ -409,15 +376,14 @@ where
     /// See the [crate-level documentation](crate#usage) for details.
     #[inline]
     pub fn owned_guard(&self) -> OwnedGuard<'_> {
-        self.raw.collector().borrow().enter_owned()
+        self.raw.collector().enter_owned()
     }
 }
 
-impl<K, V, S, C> HashMap<K, V, S, C>
+impl<K, V, S> HashMap<K, V, S>
 where
     K: Hash + Eq,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
     /// Returns the number of entries in the map.
     ///
@@ -1177,12 +1143,11 @@ pub struct OccupiedError<'a, V: 'a> {
     pub not_inserted: V,
 }
 
-impl<K, V, S, C> PartialEq for HashMap<K, V, S, C>
+impl<K, V, S> PartialEq for HashMap<K, V, S>
 where
     K: Hash + Eq,
     V: PartialEq,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
     fn eq(&self, other: &Self) -> bool {
         if self.len() != other.len() {
@@ -1196,21 +1161,19 @@ where
     }
 }
 
-impl<K, V, S, C> Eq for HashMap<K, V, S, C>
+impl<K, V, S> Eq for HashMap<K, V, S>
 where
     K: Hash + Eq,
     V: Eq,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
 }
 
-impl<K, V, S, C> fmt::Debug for HashMap<K, V, S, C>
+impl<K, V, S> fmt::Debug for HashMap<K, V, S>
 where
     K: Hash + Eq + fmt::Debug,
     V: fmt::Debug,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let guard = self.guard();
@@ -1218,11 +1181,10 @@ where
     }
 }
 
-impl<K, V, S, C> Extend<(K, V)> for &HashMap<K, V, S, C>
+impl<K, V, S> Extend<(K, V)> for &HashMap<K, V, S>
 where
     K: Hash + Eq,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
     fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
         // from `hashbrown::HashMap::extend`:
@@ -1246,12 +1208,11 @@ where
     }
 }
 
-impl<'a, K, V, S, C> Extend<(&'a K, &'a V)> for &HashMap<K, V, S, C>
+impl<'a, K, V, S> Extend<(&'a K, &'a V)> for &HashMap<K, V, S>
 where
     K: Copy + Hash + Eq,
     V: Copy,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
     fn extend<T: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: T) {
         self.extend(iter.into_iter().map(|(&key, &value)| (key, value)));
@@ -1267,25 +1228,17 @@ where
     }
 }
 
-impl<K, V, S, C> FromIterator<(K, V)> for HashMap<K, V, S, C>
+impl<K, V, S> FromIterator<(K, V)> for HashMap<K, V, S>
 where
     K: Hash + Eq,
     S: BuildHasher + Default,
-    C: Borrow<Collector> + Default,
 {
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
         let mut iter = iter.into_iter();
 
         if let Some((key, value)) = iter.next() {
             let (lower, _) = iter.size_hint();
-            let map = HashMap {
-                raw: raw::HashMap::new(
-                    lower.saturating_add(1),
-                    S::default(),
-                    C::default(),
-                    ResizeMode::default(),
-                ),
-            };
+            let map = HashMap::with_capacity_and_hasher(lower.saturating_add(1), S::default());
 
             // Ideally we could use an unprotected guard here. However, `insert`
             // returns references to values that were replaced and retired, so
@@ -1301,9 +1254,7 @@ where
 
             map
         } else {
-            HashMap {
-                raw: raw::HashMap::new(0, S::default(), C::default(), ResizeMode::default()),
-            }
+            Self::default()
         }
     }
 }
@@ -1318,31 +1269,7 @@ where
         let other = HashMap::builder()
             .capacity(self.len())
             .hasher(self.raw.hasher.clone())
-            .collector(Collector::default())
-            .build();
-
-        {
-            let (guard1, guard2) = (&self.guard(), &other.guard());
-            for (key, value) in self.iter(guard1) {
-                other.insert(key.clone(), value.clone(), guard2);
-            }
-        }
-
-        other
-    }
-}
-
-impl<K, V, S> Clone for HashMap<K, V, S, Arc<Collector>>
-where
-    K: Clone + Hash + Eq + Send + 'static,
-    V: Clone + Send + 'static,
-    S: BuildHasher + Clone,
-{
-    fn clone(&self) -> HashMap<K, V, S, Arc<Collector>> {
-        let other = HashMap::builder()
-            .capacity(self.len())
-            .hasher(self.raw.hasher.clone())
-            .shared_collector(Arc::new(Collector::default()))
+            .collector(seize::Collector::new())
             .build();
 
         {
@@ -1360,24 +1287,20 @@ where
 ///
 /// This type is created with [`HashMap::pin`] and can be used to easily access a [`HashMap`]
 /// without explicitly managing a guard. See the [crate-level documentation](crate#usage) for details.
-pub struct HashMapRef<'map, K, V, S, C, G>
-where
-    C: Borrow<Collector>,
-{
+pub struct HashMapRef<'map, K, V, S, G> {
     guard: MapGuard<G>,
-    map: &'map HashMap<K, V, S, C>,
+    map: &'map HashMap<K, V, S>,
 }
 
-impl<'map, K, V, S, C, G> HashMapRef<'map, K, V, S, C, G>
+impl<'map, K, V, S, G> HashMapRef<'map, K, V, S, G>
 where
     K: Hash + Eq,
     S: BuildHasher,
-    C: Borrow<Collector>,
     G: Guard,
 {
     /// Returns a reference to the inner [`HashMap`].
     #[inline]
-    pub fn map(&self) -> &'map HashMap<K, V, S, C> {
+    pub fn map(&self) -> &'map HashMap<K, V, S> {
         self.map
     }
 
@@ -1537,8 +1460,8 @@ where
             .update_or_insert_with(key, update, f, &self.guard)
     }
 
-    // Updates an entry with a compare-and-swap (CAS) function.
-    //
+    /// Updates an entry with a compare-and-swap (CAS) function.
+    ///
     /// See [`HashMap::compute`] for details.
     #[inline]
     pub fn compute<'g, F, T>(&'g self, key: K, compute: F) -> Compute<'g, K, V, T>
@@ -1645,12 +1568,11 @@ where
     }
 }
 
-impl<K, V, S, C, G> fmt::Debug for HashMapRef<'_, K, V, S, C, G>
+impl<K, V, S, G> fmt::Debug for HashMapRef<'_, K, V, S, G>
 where
     K: Hash + Eq + fmt::Debug,
     V: fmt::Debug,
     S: BuildHasher,
-    C: Borrow<Collector>,
     G: Guard,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1658,11 +1580,10 @@ where
     }
 }
 
-impl<'a, K, V, S, C, G> IntoIterator for &'a HashMapRef<'_, K, V, S, C, G>
+impl<'a, K, V, S, G> IntoIterator for &'a HashMapRef<'_, K, V, S, G>
 where
     K: Hash + Eq,
     S: BuildHasher,
-    C: Borrow<Collector>,
     G: Guard,
 {
     type Item = (&'a K, &'a V);

--- a/src/map.rs
+++ b/src/map.rs
@@ -93,11 +93,11 @@ where
 {
     /// Set a shared `Arc<seize::Collector>` used for garbage collection.
     ///
-    /// This method may be useful when wanting to utilize a single [`seize::Collector`] across
-    /// different `HashMap` contained in a single structure.
+    /// This method may be useful when you wish to utilize a single [`seize::Collector`] across
+    /// multiple maps contained in a single structure.
     ///
-    /// Note that to ensure the `HashMap` are reclaimed, the `Arc<seize::Collector>` must be dropped, so
-    /// it should not be owned indefinitely.
+    /// Note that the entries in the map will not be reclaimed until the `Arc<seize::Collector>`,
+    /// is dropped and so may outlive the lifetime of the map.
     pub fn shared_collector(self, collector: Arc<Collector>) -> HashMapBuilder<K, V, S> {
         HashMapBuilder {
             collector,

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -3,6 +3,7 @@ mod probe;
 
 pub(crate) mod utils;
 
+use std::borrow::Borrow;
 use std::hash::{BuildHasher, Hash};
 use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicPtr, AtomicU8, AtomicUsize, Ordering};
@@ -22,12 +23,15 @@ use seize::{Collector, LocalGuard, OwnedGuard};
 use utils::{MapGuard, Stack, VerifiedGuard};
 
 /// A lock-free hash-table.
-pub struct HashMap<K, V, S> {
+pub struct HashMap<K, V, S, C = Collector>
+where
+    C: Borrow<Collector>,
+{
     /// A pointer to the root table.
     table: AtomicPtr<RawTable<Entry<K, V>>>,
 
     /// Collector for memory reclamation.
-    collector: Collector,
+    collector: C,
 
     /// The resize mode, either blocking or incremental.
     resize: ResizeMode,
@@ -213,15 +217,18 @@ enum InsertStatus<K, V> {
     Found(EntryStatus<K, V>),
 }
 
-impl<K, V, S> HashMap<K, V, S> {
+impl<K, V, S, C> HashMap<K, V, S, C>
+where
+    C: Borrow<Collector>,
+{
     /// Creates new hash-table with the given options.
     #[inline]
     pub fn new(
         capacity: usize,
         hasher: S,
-        collector: Collector,
+        collector: C,
         resize: ResizeMode,
-    ) -> HashMap<K, V, S> {
+    ) -> HashMap<K, V, S, C> {
         // The table is lazily allocated.
         if capacity == 0 {
             return HashMap {
@@ -249,17 +256,16 @@ impl<K, V, S> HashMap<K, V, S> {
             count: Counter::default(),
         }
     }
-
     /// Returns a guard for this collector
     pub fn guard(&self) -> MapGuard<LocalGuard<'_>> {
         // Safety: Created the guard from our collector.
-        unsafe { MapGuard::new(self.collector().enter()) }
+        unsafe { MapGuard::new(self.collector().borrow().enter()) }
     }
 
     /// Returns an owned guard for this collector
     pub fn owned_guard(&self) -> MapGuard<OwnedGuard<'_>> {
         // Safety: Created the guard from our collector.
-        unsafe { MapGuard::new(self.collector().enter_owned()) }
+        unsafe { MapGuard::new(self.collector().borrow().enter_owned()) }
     }
 
     /// Verify a guard is valid to use with this map.
@@ -270,7 +276,7 @@ impl<K, V, S> HashMap<K, V, S> {
     {
         assert_eq!(
             *guard.collector(),
-            self.collector,
+            *self.collector.borrow(),
             "Attempted to access map with incorrect guard"
         );
 
@@ -290,7 +296,7 @@ impl<K, V, S> HashMap<K, V, S> {
 
     /// Returns a reference to the collector.
     #[inline]
-    pub fn collector(&self) -> &Collector {
+    pub fn collector(&self) -> &C {
         &self.collector
     }
 
@@ -307,10 +313,11 @@ impl<K, V, S> HashMap<K, V, S> {
     }
 }
 
-impl<K, V, S> HashMap<K, V, S>
+impl<K, V, S, C> HashMap<K, V, S, C>
 where
     K: Hash + Eq,
     S: BuildHasher,
+    C: Borrow<Collector>,
 {
     /// Returns a reference to the entry corresponding to the key.
     #[inline]
@@ -1384,10 +1391,11 @@ impl<K, V> LazyEntry<K, V> {
 }
 
 /// RMW operations.
-impl<K, V, S> HashMap<K, V, S>
+impl<K, V, S, C> HashMap<K, V, S, C>
 where
     K: Hash + Eq,
     S: BuildHasher,
+    C: Borrow<Collector>,
 {
     /// Tries to insert a key and value computed from a closure into the map,
     /// and returns a reference to the value that was inserted.
@@ -1850,10 +1858,11 @@ where
 }
 
 /// Resize operations.
-impl<K, V, S> HashMap<K, V, S>
+impl<K, V, S, C> HashMap<K, V, S, C>
 where
     K: Hash + Eq,
     S: BuildHasher,
+    C: Borrow<Collector>,
 {
     /// Allocate the initial table.
     #[cold]
@@ -2723,7 +2732,10 @@ impl<K, V, G> Clone for Iter<'_, K, V, G> {
     }
 }
 
-impl<K, V, S> Drop for HashMap<K, V, S> {
+impl<K, V, S, C> Drop for HashMap<K, V, S, C>
+where
+    C: Borrow<Collector>,
+{
     fn drop(&mut self) {
         let mut raw = *self.table.get_mut();
 
@@ -2733,7 +2745,7 @@ impl<K, V, S> Drop for HashMap<K, V, S> {
         // using the shared collector pointer that is invalidated by drop.
         //
         // Safety: We have a unique reference to the collector.
-        unsafe { self.collector.reclaim_all() };
+        unsafe { self.collector.borrow().reclaim_all() };
 
         // Drop all nested tables and entries.
         while !raw.is_null() {
@@ -2788,7 +2800,7 @@ unsafe fn drop_entries<K, V>(table: Table<Entry<K, V>>) {
 // # Safety
 //
 // The table must not be accessed after this call.
-unsafe fn drop_table<K, V>(mut table: Table<Entry<K, V>>, collector: &Collector) {
+unsafe fn drop_table<K, V, C: Borrow<Collector>>(mut table: Table<Entry<K, V>>, collector: &C) {
     // Drop any entries that were deferred during an incremental resize.
     //
     // Safety: Entries are deferred after they are made unreachable from the
@@ -2801,7 +2813,7 @@ unsafe fn drop_table<K, V>(mut table: Table<Entry<K, V>>, collector: &Collector)
     table
         .state_mut()
         .deferred
-        .drain(|entry| unsafe { collector.retire(entry, seize::reclaim::boxed) });
+        .drain(|entry| unsafe { collector.borrow().retire(entry, seize::reclaim::boxed) });
 
     // Deallocate the table.
     //

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -3,11 +3,10 @@ mod probe;
 
 pub(crate) mod utils;
 
-use std::borrow::Borrow;
 use std::hash::{BuildHasher, Hash};
 use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicPtr, AtomicU8, AtomicUsize, Ordering};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::{hint, panic, ptr};
 
 use self::alloc::{RawTable, Table};
@@ -23,15 +22,12 @@ use seize::{Collector, LocalGuard, OwnedGuard};
 use utils::{MapGuard, Stack, VerifiedGuard};
 
 /// A lock-free hash-table.
-pub struct HashMap<K, V, S, C = Collector>
-where
-    C: Borrow<Collector>,
-{
+pub struct HashMap<K, V, S> {
     /// A pointer to the root table.
     table: AtomicPtr<RawTable<Entry<K, V>>>,
 
     /// Collector for memory reclamation.
-    collector: C,
+    collector: Arc<Collector>,
 
     /// The resize mode, either blocking or incremental.
     resize: ResizeMode,
@@ -217,18 +213,15 @@ enum InsertStatus<K, V> {
     Found(EntryStatus<K, V>),
 }
 
-impl<K, V, S, C> HashMap<K, V, S, C>
-where
-    C: Borrow<Collector>,
-{
+impl<K, V, S> HashMap<K, V, S> {
     /// Creates new hash-table with the given options.
     #[inline]
     pub fn new(
         capacity: usize,
         hasher: S,
-        collector: C,
+        collector: Arc<Collector>,
         resize: ResizeMode,
-    ) -> HashMap<K, V, S, C> {
+    ) -> HashMap<K, V, S> {
         // The table is lazily allocated.
         if capacity == 0 {
             return HashMap {
@@ -259,13 +252,13 @@ where
     /// Returns a guard for this collector
     pub fn guard(&self) -> MapGuard<LocalGuard<'_>> {
         // Safety: Created the guard from our collector.
-        unsafe { MapGuard::new(self.collector().borrow().enter()) }
+        unsafe { MapGuard::new(self.collector().enter()) }
     }
 
     /// Returns an owned guard for this collector
     pub fn owned_guard(&self) -> MapGuard<OwnedGuard<'_>> {
         // Safety: Created the guard from our collector.
-        unsafe { MapGuard::new(self.collector().borrow().enter_owned()) }
+        unsafe { MapGuard::new(self.collector().enter_owned()) }
     }
 
     /// Verify a guard is valid to use with this map.
@@ -276,7 +269,7 @@ where
     {
         assert_eq!(
             *guard.collector(),
-            *self.collector.borrow(),
+            *self.collector,
             "Attempted to access map with incorrect guard"
         );
 
@@ -296,7 +289,7 @@ where
 
     /// Returns a reference to the collector.
     #[inline]
-    pub fn collector(&self) -> &C {
+    pub fn collector(&self) -> &Collector {
         &self.collector
     }
 
@@ -313,11 +306,10 @@ where
     }
 }
 
-impl<K, V, S, C> HashMap<K, V, S, C>
+impl<K, V, S> HashMap<K, V, S>
 where
     K: Hash + Eq,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
     /// Returns a reference to the entry corresponding to the key.
     #[inline]
@@ -1391,11 +1383,10 @@ impl<K, V> LazyEntry<K, V> {
 }
 
 /// RMW operations.
-impl<K, V, S, C> HashMap<K, V, S, C>
+impl<K, V, S> HashMap<K, V, S>
 where
     K: Hash + Eq,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
     /// Tries to insert a key and value computed from a closure into the map,
     /// and returns a reference to the value that was inserted.
@@ -1858,11 +1849,10 @@ where
 }
 
 /// Resize operations.
-impl<K, V, S, C> HashMap<K, V, S, C>
+impl<K, V, S> HashMap<K, V, S>
 where
     K: Hash + Eq,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
     /// Allocate the initial table.
     #[cold]
@@ -2732,10 +2722,7 @@ impl<K, V, G> Clone for Iter<'_, K, V, G> {
     }
 }
 
-impl<K, V, S, C> Drop for HashMap<K, V, S, C>
-where
-    C: Borrow<Collector>,
-{
+impl<K, V, S> Drop for HashMap<K, V, S> {
     fn drop(&mut self) {
         let mut raw = *self.table.get_mut();
 
@@ -2745,7 +2732,7 @@ where
         // using the shared collector pointer that is invalidated by drop.
         //
         // Safety: We have a unique reference to the collector.
-        unsafe { self.collector.borrow().reclaim_all() };
+        unsafe { self.collector.reclaim_all() };
 
         // Drop all nested tables and entries.
         while !raw.is_null() {
@@ -2800,7 +2787,7 @@ unsafe fn drop_entries<K, V>(table: Table<Entry<K, V>>) {
 // # Safety
 //
 // The table must not be accessed after this call.
-unsafe fn drop_table<K, V, C: Borrow<Collector>>(mut table: Table<Entry<K, V>>, collector: &C) {
+unsafe fn drop_table<K, V>(mut table: Table<Entry<K, V>>, collector: &Collector) {
     // Drop any entries that were deferred during an incremental resize.
     //
     // Safety: Entries are deferred after they are made unreachable from the
@@ -2813,7 +2800,7 @@ unsafe fn drop_table<K, V, C: Borrow<Collector>>(mut table: Table<Entry<K, V>>, 
     table
         .state_mut()
         .deferred
-        .drain(|entry| unsafe { collector.borrow().retire(entry, seize::reclaim::boxed) });
+        .drain(|entry| unsafe { collector.retire(entry, seize::reclaim::boxed) });
 
     // Deallocate the table.
     //

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -1,28 +1,21 @@
-use seize::Collector;
 use serde::de::{MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use std::borrow::Borrow;
 use std::fmt::{self, Formatter};
 use std::hash::{BuildHasher, Hash};
 use std::marker::PhantomData;
-use std::sync::Arc;
 
 use crate::{Guard, HashMap, HashMapRef, HashSet, HashSetRef};
 
-struct MapVisitor<K, V, S, C = Collector>
-where
-    C: Borrow<Collector>,
-{
-    _marker: PhantomData<HashMap<K, V, S, C>>,
+struct MapVisitor<K, V, S> {
+    _marker: PhantomData<HashMap<K, V, S>>,
 }
 
-impl<K, V, S, C, G> Serialize for HashMapRef<'_, K, V, S, C, G>
+impl<K, V, S, G> Serialize for HashMapRef<'_, K, V, S, G>
 where
     K: Serialize + Hash + Eq,
     V: Serialize,
     G: Guard,
-    C: Borrow<Collector>,
     S: BuildHasher,
 {
     fn serialize<Sr>(&self, serializer: Sr) -> Result<Sr::Ok, Sr::Error>
@@ -33,12 +26,11 @@ where
     }
 }
 
-impl<K, V, S, C> Serialize for HashMap<K, V, S, C>
+impl<K, V, S> Serialize for HashMap<K, V, S>
 where
     K: Serialize + Hash + Eq,
     V: Serialize,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
     fn serialize<Sr>(&self, serializer: Sr) -> Result<Sr::Ok, Sr::Error>
     where
@@ -102,17 +94,13 @@ where
     }
 }
 
-struct SetVisitor<K, S, C>
-where
-    C: Borrow<Collector>,
-{
-    _marker: PhantomData<HashSet<K, S, C>>,
+struct SetVisitor<K, S> {
+    _marker: PhantomData<HashSet<K, S>>,
 }
 
-impl<K, S, C, G> Serialize for HashSetRef<'_, K, S, C, G>
+impl<K, S, G> Serialize for HashSetRef<'_, K, S, G>
 where
     K: Serialize + Hash + Eq,
-    C: Borrow<Collector>,
     G: Guard,
     S: BuildHasher,
 {
@@ -124,11 +112,10 @@ where
     }
 }
 
-impl<K, S, C> Serialize for HashSet<K, S, C>
+impl<K, S> Serialize for HashSet<K, S>
 where
     K: Serialize + Hash + Eq,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
     fn serialize<Sr>(&self, serializer: Sr) -> Result<Sr::Ok, Sr::Error>
     where
@@ -147,39 +134,19 @@ where
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_seq(SetVisitor::<K, S, Collector>::new())
+        deserializer.deserialize_seq(SetVisitor::new())
     }
 }
 
-impl<'de, K, S> Deserialize<'de> for HashSet<K, S, Arc<Collector>>
-where
-    K: Deserialize<'de> + Hash + Eq + Send + 'static,
-    S: Default + BuildHasher,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_seq(SetVisitor::<K, S, Arc<Collector>>::new())
-    }
-}
-
-impl<K, S> SetVisitor<K, S, Collector> {
+impl<K, S> SetVisitor<K, S> {
     pub(crate) fn new() -> Self {
         Self {
             _marker: PhantomData,
         }
     }
 }
-impl<K, S> SetVisitor<K, S, Arc<Collector>> {
-    pub(crate) fn new() -> SetVisitor<K, S, Arc<Collector>> {
-        Self {
-            _marker: PhantomData,
-        }
-    }
-}
 
-impl<'de, K, S> Visitor<'de> for SetVisitor<K, S, Collector>
+impl<'de, K, S> Visitor<'de> for SetVisitor<K, S>
 where
     K: Deserialize<'de> + Hash + Eq,
     S: Default + BuildHasher,
@@ -197,45 +164,6 @@ where
         let values = match access.size_hint() {
             Some(size) => HashSet::with_capacity_and_hasher(size, S::default()),
             None => HashSet::default(),
-        };
-
-        {
-            let values = values.pin();
-            while let Some(key) = access.next_element()? {
-                values.insert(key);
-            }
-        }
-
-        Ok(values)
-    }
-}
-
-impl<'de, K, S> Visitor<'de> for SetVisitor<K, S, Arc<Collector>>
-where
-    K: Deserialize<'de> + Hash + Eq + Send + 'static,
-    S: Default + BuildHasher,
-{
-    type Value = HashSet<K, S, Arc<Collector>>;
-
-    fn expecting(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "a set")
-    }
-
-    fn visit_seq<M>(self, mut access: M) -> Result<Self::Value, M::Error>
-    where
-        M: SeqAccess<'de>,
-    {
-        let values = match access.size_hint() {
-            Some(size) => HashSet::builder()
-                .hasher(S::default())
-                .shared_collector(Arc::new(Collector::new()))
-                .capacity(size)
-                .build(),
-            None => HashSet::builder()
-                .hasher(S::default())
-                .shared_collector(Arc::new(Collector::new()))
-                .capacity(0)
-                .build(),
         };
 
         {

--- a/src/set.rs
+++ b/src/set.rs
@@ -81,11 +81,11 @@ where
 {
     /// Set a shared `Arc<seize::Collector>` used for garbage collection.
     ///
-    /// This method may be useful when wanting to utilize a single [`seize::Collector`] across
-    /// different `HashSet` contained in a single structure.
+    /// This method may be useful when you wish to utilize a single [`seize::Collector`] across
+    /// multiple sets contained in a single structure.
     ///
-    /// Note that to ensure the `HashSet` are reclaimed, the `Arc<seize::Collector>` must be dropped, so
-    /// it should not be owned indefinitely.
+    /// Note that the entries in the set will not be reclaimed until the `Arc<seize::Collector>`,
+    /// is dropped and so may outlive the lifetime of the map.
     pub fn shared_collector(self, collector: Arc<Collector>) -> HashSetBuilder<K, S> {
         HashSetBuilder {
             collector,

--- a/src/set.rs
+++ b/src/set.rs
@@ -4,7 +4,6 @@ use crate::Equivalent;
 use seize::{Collector, Guard, LocalGuard, OwnedGuard};
 
 use crate::map::ResizeMode;
-use std::borrow::Borrow;
 use std::collections::hash_map::RandomState;
 use std::fmt;
 use std::hash::{BuildHasher, Hash};
@@ -16,18 +15,15 @@ use std::sync::Arc;
 /// Most hash set operations require a [`Guard`](crate::Guard), which can be acquired through
 /// [`HashSet::guard`] or using the [`HashSet::pin`] API. See the [crate-level documentation](crate#usage)
 /// for details.
-pub struct HashSet<K, S = RandomState, C = Collector>
-where
-    C: Borrow<Collector>,
-{
-    raw: raw::HashMap<K, (), S, C>,
+pub struct HashSet<K, S = RandomState> {
+    raw: raw::HashMap<K, (), S>,
 }
 
 // Safety: We only ever hand out &K through shared references to the map,
 // so normal Send/Sync rules apply. We never expose owned or mutable references
 // to keys or values.
-unsafe impl<K: Send, S: Send, C: Send + Borrow<Collector>> Send for HashSet<K, S, C> {}
-unsafe impl<K: Sync, S: Sync, C: Sync + Borrow<Collector>> Sync for HashSet<K, S, C> {}
+unsafe impl<K: Send, S: Send> Send for HashSet<K, S> {}
+unsafe impl<K: Sync, S: Sync> Sync for HashSet<K, S> {}
 
 /// A builder for a [`HashSet`].
 ///
@@ -50,13 +46,10 @@ unsafe impl<K: Sync, S: Sync, C: Sync + Borrow<Collector>> Sync for HashSet<K, S
 ///     // Construct the hash set.
 ///     .build();
 /// ```
-pub struct HashSetBuilder<K, S = RandomState, C = Collector>
-where
-    C: Borrow<Collector>,
-{
+pub struct HashSetBuilder<K, S = RandomState> {
     hasher: S,
     capacity: usize,
-    collector: C,
+    collector: Arc<Collector>,
     resize_mode: ResizeMode,
     _kv: PhantomData<K>,
 }
@@ -82,24 +75,6 @@ impl<K> HashSetBuilder<K> {
     }
 }
 
-impl<K, S> HashSetBuilder<K, S> {
-    /// Set the [`seize::Collector`] used for garbage collection.
-    ///
-    /// This method may be useful when you want more control over garbage collection.
-    ///
-    /// Note that all `Guard` references used to access the set must be produced by
-    /// the provided `collector`.
-    pub fn collector(self, collector: Collector) -> HashSetBuilder<K, S> {
-        HashSetBuilder {
-            collector,
-            hasher: self.hasher,
-            capacity: self.capacity,
-            resize_mode: self.resize_mode,
-            _kv: PhantomData,
-        }
-    }
-}
-
 impl<K, S> HashSetBuilder<K, S>
 where
     K: Send + 'static,
@@ -111,10 +86,7 @@ where
     ///
     /// Note that to ensure the `HashSet` are reclaimed, the `Arc<seize::Collector>` must be dropped, so
     /// it should not be owned indefinitely.
-    pub fn shared_collector(
-        self,
-        collector: Arc<Collector>,
-    ) -> HashSetBuilder<K, S, Arc<Collector>> {
+    pub fn shared_collector(self, collector: Arc<Collector>) -> HashSetBuilder<K, S> {
         HashSetBuilder {
             collector,
             hasher: self.hasher,
@@ -125,16 +97,28 @@ where
     }
 }
 
-impl<K, S, C> HashSetBuilder<K, S, C>
-where
-    C: Borrow<Collector>,
-{
+impl<K, S> HashSetBuilder<K, S> {
+    /// Set the [`seize::Collector`] used for garbage collection.
+    ///
+    /// This method may be useful when you want more control over garbage collection.
+    ///
+    /// Note that all `Guard` references used to access the set must be produced by
+    /// the provided `collector`.
+    pub fn collector(self, collector: Collector) -> HashSetBuilder<K, S> {
+        HashSetBuilder {
+            collector: Arc::new(collector),
+            hasher: self.hasher,
+            capacity: self.capacity,
+            resize_mode: self.resize_mode,
+            _kv: PhantomData,
+        }
+    }
     /// Set the initial capacity of the set.
     ///
     /// The set should be able to hold at least `capacity` elements before resizing.
     /// However, the capacity is an estimate, and the set may prematurely resize due
     /// to poor hash distribution. If `capacity` is 0, the hash set will not allocate.
-    pub fn capacity(self, capacity: usize) -> HashSetBuilder<K, S, C> {
+    pub fn capacity(self, capacity: usize) -> HashSetBuilder<K, S> {
         HashSetBuilder {
             capacity,
             hasher: self.hasher,
@@ -156,17 +140,14 @@ where
     }
 
     /// Construct a [`HashSet`] from the builder, using the configured options.
-    pub fn build(self) -> HashSet<K, S, C> {
+    pub fn build(self) -> HashSet<K, S> {
         HashSet {
             raw: raw::HashMap::new(self.capacity, self.hasher, self.collector, self.resize_mode),
         }
     }
 }
 
-impl<K, S, C> fmt::Debug for HashSetBuilder<K, S, C>
-where
-    C: Borrow<Collector> + fmt::Debug,
-{
+impl<K, S> fmt::Debug for HashSetBuilder<K, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("HashSetBuilder")
             .field("capacity", &self.capacity)
@@ -189,7 +170,7 @@ impl<K> HashSet<K> {
     /// let map: HashSet<&str> = HashSet::new();
     /// ```
     pub fn new() -> HashSet<K> {
-        HashSet::with_capacity_and_hasher(0, RandomState::default())
+        HashSet::with_capacity_and_hasher(0, RandomState::new())
     }
 
     /// Creates an empty `HashSet` with the specified capacity.
@@ -205,7 +186,7 @@ impl<K> HashSet<K> {
     /// let set: HashSet<&str> = HashSet::with_capacity(10);
     /// ```
     pub fn with_capacity(capacity: usize) -> HashSet<K> {
-        HashSet::with_capacity_and_hasher(capacity, RandomState::default())
+        HashSet::with_capacity_and_hasher(capacity, RandomState::new())
     }
 
     /// Returns a builder for a `HashSet`.
@@ -216,7 +197,7 @@ impl<K> HashSet<K> {
         HashSetBuilder {
             capacity: 0,
             hasher: RandomState::default(),
-            collector: Collector::default(),
+            collector: Arc::new(Collector::default()),
             resize_mode: ResizeMode::default(),
             _kv: PhantomData,
         }
@@ -229,19 +210,6 @@ where
 {
     fn default() -> Self {
         HashSet::with_hasher(S::default())
-    }
-}
-
-impl<K, S> Default for HashSet<K, S, Arc<Collector>>
-where
-    S: Default,
-    K: Send + 'static,
-{
-    fn default() -> Self {
-        HashSet::builder()
-            .hasher(S::default())
-            .shared_collector(Arc::new(Collector::new()))
-            .build()
     }
 }
 
@@ -301,23 +269,18 @@ impl<K, S> HashSet<K, S> {
             raw: raw::HashMap::new(
                 capacity,
                 hash_builder,
-                Collector::default(),
+                Arc::new(Collector::default()),
                 ResizeMode::default(),
             ),
         }
     }
-}
 
-impl<K, S, C> HashSet<K, S, C>
-where
-    C: Borrow<Collector>,
-{
     /// Returns a pinned reference to the set.
     ///
     /// The returned reference manages a guard internally, preventing garbage collection
     /// for as long as it is held. See the [crate-level documentation](crate#usage) for details.
     #[inline]
-    pub fn pin(&self) -> HashSetRef<'_, K, S, C, LocalGuard<'_>> {
+    pub fn pin(&self) -> HashSetRef<'_, K, S, LocalGuard<'_>> {
         HashSetRef {
             guard: self.raw.guard(),
             set: self,
@@ -333,7 +296,7 @@ where
     /// The returned reference manages a guard internally, preventing garbage collection
     /// for as long as it is held. See the [crate-level documentation](crate#usage) for details.
     #[inline]
-    pub fn pin_owned(&self) -> HashSetRef<'_, K, S, C, OwnedGuard<'_>> {
+    pub fn pin_owned(&self) -> HashSetRef<'_, K, S, OwnedGuard<'_>> {
         HashSetRef {
             guard: self.raw.owned_guard(),
             set: self,
@@ -346,7 +309,7 @@ where
     /// See the [crate-level documentation](crate#usage) for details.
     #[inline]
     pub fn guard(&self) -> LocalGuard<'_> {
-        self.raw.collector().borrow().enter()
+        self.raw.collector().enter()
     }
 
     /// Returns an owned guard for use with this set.
@@ -359,15 +322,14 @@ where
     /// See the [crate-level documentation](crate#usage) for details.
     #[inline]
     pub fn owned_guard(&self) -> OwnedGuard<'_> {
-        self.raw.collector().borrow().enter_owned()
+        self.raw.collector().enter_owned()
     }
 }
 
-impl<K, S, C> HashSet<K, S, C>
+impl<K, S> HashSet<K, S>
 where
     K: Hash + Eq,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
     /// Returns the number of entries in the set.
     ///
@@ -631,11 +593,10 @@ where
     }
 }
 
-impl<K, S, C> PartialEq for HashSet<K, S, C>
+impl<K, S> PartialEq for HashSet<K, S>
 where
     K: Hash + Eq,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
     fn eq(&self, other: &Self) -> bool {
         if self.len() != other.len() {
@@ -649,18 +610,16 @@ where
     }
 }
 
-impl<K, S, C> Eq for HashSet<K, S, C>
+impl<K, S> Eq for HashSet<K, S>
 where
     K: Hash + Eq,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
 }
 
-impl<K, S, C> fmt::Debug for HashSet<K, S, C>
+impl<K, S> fmt::Debug for HashSet<K, S>
 where
     K: Hash + Eq + fmt::Debug,
-    C: Borrow<Collector> + fmt::Debug,
     S: BuildHasher,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -669,11 +628,10 @@ where
     }
 }
 
-impl<K, S, C> Extend<K> for &HashSet<K, S, C>
+impl<K, S> Extend<K> for &HashSet<K, S>
 where
     K: Hash + Eq,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
     fn extend<T: IntoIterator<Item = K>>(&mut self, iter: T) {
         // from `hashbrown::HashSet::extend`:
@@ -697,11 +655,10 @@ where
     }
 }
 
-impl<'a, K, S, C> Extend<&'a K> for &HashSet<K, S, C>
+impl<'a, K, S> Extend<&'a K> for &HashSet<K, S>
 where
     K: Copy + Hash + Eq + 'a,
     S: BuildHasher,
-    C: Borrow<Collector>,
 {
     fn extend<T: IntoIterator<Item = &'a K>>(&mut self, iter: T) {
         self.extend(iter.into_iter().copied());
@@ -717,25 +674,17 @@ where
     }
 }
 
-impl<K, S, C> FromIterator<K> for HashSet<K, S, C>
+impl<K, S> FromIterator<K> for HashSet<K, S>
 where
     K: Hash + Eq,
     S: BuildHasher + Default,
-    C: Borrow<Collector> + Default,
 {
     fn from_iter<T: IntoIterator<Item = K>>(iter: T) -> Self {
         let mut iter = iter.into_iter();
 
         if let Some(key) = iter.next() {
             let (lower, _) = iter.size_hint();
-            let set = HashSet {
-                raw: raw::HashMap::new(
-                    lower.saturating_add(1),
-                    S::default(),
-                    C::default(),
-                    ResizeMode::default(),
-                ),
-            };
+            let set = HashSet::with_capacity_and_hasher(lower.saturating_add(1), S::default());
 
             // Ideally we could use an unprotected guard here. However, `insert`
             // returns references to values that were replaced and retired, so
@@ -751,9 +700,7 @@ where
 
             set
         } else {
-            HashSet {
-                raw: raw::HashMap::new(0, S::default(), C::default(), ResizeMode::default()),
-            }
+            Self::default()
         }
     }
 }
@@ -781,51 +728,24 @@ where
     }
 }
 
-impl<K, S> Clone for HashSet<K, S, Arc<Collector>>
-where
-    K: Clone + Hash + Eq + Send + 'static,
-    S: BuildHasher + Clone,
-{
-    fn clone(&self) -> HashSet<K, S, Arc<Collector>> {
-        let other = HashSet::builder()
-            .capacity(self.len())
-            .hasher(self.raw.hasher.clone())
-            .shared_collector(Arc::new(seize::Collector::new()))
-            .build();
-
-        {
-            let (guard1, guard2) = (&self.guard(), &other.guard());
-            for key in self.iter(guard1) {
-                other.insert(key.clone(), guard2);
-            }
-        }
-
-        other
-    }
-}
-
 /// A pinned reference to a [`HashSet`].
 ///
 /// This type is created with [`HashSet::pin`] and can be used to easily access a [`HashSet`]
 /// without explicitly managing a guard. See the [crate-level documentation](crate#usage) for details.
-pub struct HashSetRef<'set, K, S, C, G>
-where
-    C: Borrow<Collector>,
-{
+pub struct HashSetRef<'set, K, S, G> {
     guard: MapGuard<G>,
-    set: &'set HashSet<K, S, C>,
+    set: &'set HashSet<K, S>,
 }
 
-impl<'set, K, S, C, G> HashSetRef<'set, K, S, C, G>
+impl<'set, K, S, G> HashSetRef<'set, K, S, G>
 where
     K: Hash + Eq,
     S: BuildHasher,
     G: Guard,
-    C: Borrow<Collector>,
 {
     /// Returns a reference to the inner [`HashSet`].
     #[inline]
-    pub fn set(&self) -> &'set HashSet<K, S, C> {
+    pub fn set(&self) -> &'set HashSet<K, S> {
         self.set
     }
 
@@ -937,11 +857,10 @@ where
     }
 }
 
-impl<K, S, C, G> fmt::Debug for HashSetRef<'_, K, S, C, G>
+impl<K, S, G> fmt::Debug for HashSetRef<'_, K, S, G>
 where
     K: Hash + Eq + fmt::Debug,
     S: BuildHasher,
-    C: Borrow<Collector> + fmt::Debug,
     G: Guard,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -949,11 +868,10 @@ where
     }
 }
 
-impl<'a, K, S, C, G> IntoIterator for &'a HashSetRef<'_, K, S, C, G>
+impl<'a, K, S, G> IntoIterator for &'a HashSetRef<'_, K, S, G>
 where
     K: Hash + Eq,
     S: BuildHasher,
-    C: Borrow<Collector>,
     G: Guard,
 {
     type Item = &'a K;

--- a/src/set.rs
+++ b/src/set.rs
@@ -84,8 +84,8 @@ where
     /// This method may be useful when you wish to utilize a single [`seize::Collector`] across
     /// multiple sets contained in a single structure.
     ///
-    /// Note that the entries in the set will not be reclaimed until the `Arc<seize::Collector>`,
-    /// is dropped and so may outlive the lifetime of the map.
+    /// Note that the entries in the set will not be reclaimed until the `Arc<seize::Collector>`
+    /// is dropped, and so may outlive the lifetime of the map.
     pub fn shared_collector(self, collector: Arc<Collector>) -> HashSetBuilder<K, S> {
         HashSetBuilder {
             collector,


### PR DESCRIPTION
As previously discussed in #66, this change is motivated by the memory usage of a freshly initialized `HashMap` or `HashSet`, which is ~1kB. This is can cause memory usage to grow quite fast when defining multiple `HashMap` within a single struct. 

The change simply adds a `C: Borrow<Collector>` generic to the `HashMap`, so in order to make the API safe we constrain such setting to a `shared_controller` builder function with bounds `K: Send + 'static, V: Send + 'static`, which should be enough to enforce safety from my understanding.

The implemented `Clone` behavior for `HashMap<K, V, S, Arc<Collector>>` is to simply create a new `Arc<Collector>` rather than cloning it, as that seems the safer approach, even though it might be slightly confusing. 
