### PR TITLE
Make seize/fast-barrier optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["assets/*"]
 
 [dependencies]
 equivalent = "1"
-seize = "0.5"
+seize = { version = "0.5" , default-features = false }
 serde = { version = "1", optional = true }
 
 [dev-dependencies]
@@ -28,8 +28,9 @@ num_cpus = "1"
 serde_json = "1"
 
 [features]
-default = []
+default = ["fast-barrier"]
 serde = ["dep:serde"]
+fast-barrier = ["seize/fast-barrier"]
 
 [profile.test]
 inherits = "release"


### PR DESCRIPTION
The fast-barrier feature can have overhead when the hashmap isn't created on the main thread, which is noticeable especially with short-running CLI tools. In uv, we found that papaya initialization began dominating, taking 15ms to 25ms on linux (https://github.com/astral-sh/uv/pull/20989).

By forwarding the `fast-barrier` feature from seize, users of papaya can deselect the feature and get the better performance.

This is likely related to https://github.com/ibraheemdev/papaya/issues/94